### PR TITLE
feature/apvs-372/mark upload later claims as pending

### DIFF
--- a/app/services/data/copy-first-time-claim-data-to-internal.js
+++ b/app/services/data/copy-first-time-claim-data-to-internal.js
@@ -9,7 +9,7 @@ module.exports = function (data) {
     .then(function () {
       data.Claim.Status = statusEnum.NEW
       data.ClaimDocument.forEach(function (document) {
-        if (document.DocumentStatus === 'post-later') {
+        if (document.DocumentStatus !== 'uploaded') {
           data.Claim.Status = statusEnum.PENDING
         }
       })

--- a/test/integration/services/data/test-copy-first-time-claim-data-to-internal.js
+++ b/test/integration/services/data/test-copy-first-time-claim-data-to-internal.js
@@ -5,12 +5,11 @@ const statusEnum = require('../../../../app/constants/status-enum')
 const testHelper = require('../../../test-helper')
 
 const copyFirstTimeClaimDataToInternal = require('../../../../app/services/data/copy-first-time-claim-data-to-internal')
+var reference = 'COPY123'
+var claimId = 123
+var firstTimeClaimData = testHelper.getFirstTimeClaimData(reference, claimId)
 
 describe('services/data/copy-first-time-claim-data-to-internal', function () {
-  var reference = 'COPY123'
-  var claimId = 123
-  var firstTimeClaimData = testHelper.getFirstTimeClaimData(reference, claimId)
-
   it('should copy the first time claim data to internal', function () {
     return copyFirstTimeClaimDataToInternal(firstTimeClaimData).then(function () {
       return knex('IntSchema.Eligibility').where('IntSchema.Eligibility.Reference', reference)
@@ -31,11 +30,14 @@ describe('services/data/copy-first-time-claim-data-to-internal', function () {
           expect(results[0].PrisonNumber).to.be.equal(firstTimeClaimData.Prisoner.PrisonNumber)
         })
     })
-    .then(function () {
-      return testHelper.deleteAll(reference, 'IntSchema')
-    })
   })
 
+  after(function () {
+    return testHelper.deleteAll(reference, 'IntSchema')
+  })
+})
+
+describe('services/data/copy-first-time-claim-data-to-internal', function () {
   it('should copy the first time claim data to internal with claim status NEW if all documents uploaded', function () {
     firstTimeClaimData.ClaimDocument.forEach(function (document) {
       if (document.DocumentStatus !== 'uploaded') {
@@ -49,12 +51,15 @@ describe('services/data/copy-first-time-claim-data-to-internal', function () {
           expect(results[0].Status, 'Claim.Status should be NEW').to.be.equal(statusEnum.NEW)
         })
     })
-    .then(function () {
-      return testHelper.deleteAll(reference, 'IntSchema')
-    })
   })
 
-  it('should change claim status to PENDING if documents will be uploaded later', function () {
+  after(function () {
+    return testHelper.deleteAll(reference, 'IntSchema')
+  })
+})
+
+describe('services/data/copy-first-time-claim-data-to-internal', function () {
+  it('should change claim status to PENDING if documents not uploaded', function () {
     firstTimeClaimData.ClaimDocument.forEach(function (document) {
       if (document.DocumentStatus !== 'upload-later') {
         document.DocumentStatus = 'upload-later'

--- a/test/integration/services/data/test-copy-first-time-claim-data-to-internal.js
+++ b/test/integration/services/data/test-copy-first-time-claim-data-to-internal.js
@@ -21,7 +21,7 @@ describe('services/data/copy-first-time-claim-data-to-internal', function () {
         .select()
         .then(function (results) {
           expect(results[0].Status[0], 'Eligibility.Status should be NEW').to.be.equal(statusEnum.NEW)
-          expect(results[0].Status[1], 'Claim.Status should be PENDING').to.be.equal(statusEnum.PENDING)
+          expect(results[0].Status[1], 'Claim.Status should be NEW').to.be.equal(statusEnum.NEW)
           expect(results[0].AccountNumber).to.be.equal(firstTimeClaimData.ClaimBankDetail.AccountNumber)
           expect(results.length, 'Should have two ClaimExpense').to.be.equal(2)
           expect(results[0].ExpenseType).to.be.equal('car')
@@ -38,33 +38,10 @@ describe('services/data/copy-first-time-claim-data-to-internal', function () {
 })
 
 describe('services/data/copy-first-time-claim-data-to-internal', function () {
-  it('should copy the first time claim data to internal with claim status NEW if all documents uploaded', function () {
-    firstTimeClaimData.ClaimDocument.forEach(function (document) {
-      if (document.DocumentStatus !== 'uploaded') {
-        document.DocumentStatus = 'uploaded'
-      }
-    })
-    return copyFirstTimeClaimDataToInternal(firstTimeClaimData).then(function () {
-      return knex('IntSchema.Claim').where('IntSchema.Claim.Reference', reference)
-        .select('Claim.Status')
-        .then(function (results) {
-          expect(results[0].Status, 'Claim.Status should be NEW').to.be.equal(statusEnum.NEW)
-        })
-    })
-  })
-
-  after(function () {
-    return testHelper.deleteAll(reference, 'IntSchema')
-  })
-})
-
-describe('services/data/copy-first-time-claim-data-to-internal', function () {
   it('should change claim status to PENDING if documents not uploaded', function () {
-    firstTimeClaimData.ClaimDocument.forEach(function (document) {
-      if (document.DocumentStatus !== 'upload-later') {
-        document.DocumentStatus = 'upload-later'
-      }
-    })
+    firstTimeClaimData.ClaimDocument[0].DocumentStatus = 'post-later'
+    firstTimeClaimData.ClaimDocument[1].DocumentStatus = 'upload-later'
+
     return copyFirstTimeClaimDataToInternal(firstTimeClaimData).then(function () {
       return knex('IntSchema.Claim').where('IntSchema.Claim.Reference', reference)
         .select('Claim.Status')

--- a/test/integration/services/data/test-copy-first-time-claim-data-to-internal.js
+++ b/test/integration/services/data/test-copy-first-time-claim-data-to-internal.js
@@ -49,6 +49,24 @@ describe('services/data/copy-first-time-claim-data-to-internal', function () {
           expect(results[0].Status, 'Claim.Status should be NEW').to.be.equal(statusEnum.NEW)
         })
     })
+    .then(function () {
+      return testHelper.deleteAll(reference, 'IntSchema')
+    })
+  })
+
+  it('should change claim status to PENDING if documents will be uploaded later', function () {
+    firstTimeClaimData.ClaimDocument.forEach(function (document) {
+      if (document.DocumentStatus !== 'upload-later') {
+        document.DocumentStatus = 'upload-later'
+      }
+    })
+    return copyFirstTimeClaimDataToInternal(firstTimeClaimData).then(function () {
+      return knex('IntSchema.Claim').where('IntSchema.Claim.Reference', reference)
+        .select('Claim.Status')
+        .then(function (results) {
+          expect(results[0].Status, 'Claim.Status should be PENDING').to.be.equal(statusEnum.PENDING)
+        })
+    })
   })
 
   after(function () {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -220,7 +220,7 @@ module.exports.getFirstTimeClaimData = function (reference) {
         ClaimId: uniqueId,
         DocumentType: 'BENEFIT',
         ClaimExpenseId: null,
-        DocumentStatus: 'post-later',
+        DocumentStatus: 'uploaded',
         Filepath: null,
         DateSubmitted: new Date(),
         IsEnabled: true}],


### PR DESCRIPTION
apvs-372 - mark upload later claims as pending

If a claim document has not been uploaded the claim will be marked as pending.

## Checklist

- [ ] Unit tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated

