### PR TITLE
Feature/apvs 365/auto approval send notification

### DIFF
--- a/app/services/auto-approval/auto-approval-process.js
+++ b/app/services/auto-approval/auto-approval-process.js
@@ -1,7 +1,9 @@
 const config = require('../../../knexfile').asyncworker
 const knex = require('knex')(config)
 
+const insertTask = require('../data/insert-task')
 const getDataForAutoApprovalChecks = require('../data/get-data-for-auto-approval-check')
+const tasksEnum = require('../../constants/tasks-enum')
 const statusEnum = require('../../constants/status-enum')
 
 const autoApprovalChecks = [
@@ -37,6 +39,9 @@ module.exports = function (claimData) {
         return knex('IntSchema.Claim')
           .where('ClaimId', claimData.Claim.ClaimId)
           .update('Status', statusEnum.AUTOAPPROVED)
+          .then(function () {
+            return insertTask(claimData.Claim.Reference, claimData.Claim.EligibilityId, claimData.Claim.ClaimId, tasksEnum.ACCEPT_CLAIM_NOTIFICATION)
+          })
           .then(function () {
             return result
           })

--- a/app/services/auto-approval/auto-approval-process.js
+++ b/app/services/auto-approval/auto-approval-process.js
@@ -1,5 +1,6 @@
 const config = require('../../../knexfile').asyncworker
 const knex = require('knex')(config)
+const Promise = require('bluebird')
 
 const insertTask = require('../data/insert-task')
 const getDataForAutoApprovalChecks = require('../data/get-data-for-auto-approval-check')
@@ -26,7 +27,7 @@ module.exports = function (claimData) {
   // Fail auto-approval check if status has been set to Pending in the copy-claim-data-to-internal module
   if (claimData.Claim.Status === statusEnum.PENDING) {
     result.claimApproved = false
-    return result
+    return Promise.resolve(result)
   }
 
   return getDataForAutoApprovalChecks(claimData.Claim)
@@ -45,6 +46,7 @@ module.exports = function (claimData) {
       })
 
       if (result.claimApproved) {
+        // TODO refactor to move this to data function, so this module can be unit tested without DB dependencies
         return knex('IntSchema.Claim')
           .where('ClaimId', claimData.Claim.ClaimId)
           .update('Status', statusEnum.AUTOAPPROVED)

--- a/app/services/auto-approval/auto-approval-process.js
+++ b/app/services/auto-approval/auto-approval-process.js
@@ -7,8 +7,17 @@ const tasksEnum = require('../../constants/tasks-enum')
 const statusEnum = require('../../constants/status-enum')
 
 const autoApprovalChecks = [
+  require('./checks/are-children-under-18'),
+  require('./checks/cost-and-variance-equal-or-less-than-first-time-claim'),
+  require('./checks/do-expenses-match-first-time-claim'),
+  require('./checks/has-claimed-less-than-max-times-this-year'),
+  require('./checks/has-uploaded-prison-visit-confirmation-and-receipts'),
+  require('./checks/is-claim-submitted-within-time-limit'),
+  require('./checks/is-claim-total-under-limit'),
   require('./checks/is-latest-manual-claim-approved'),
-  require('./checks/is-no-previous-pending-claim')
+  require('./checks/is-no-previous-pending-claim'),
+  require('./checks/is-visit-in-past'),
+  require('./checks/visit-date-different-to-previous-claims')
 ]
 
 module.exports = function (claimData) {

--- a/app/services/data/insert-task.js
+++ b/app/services/data/insert-task.js
@@ -1,11 +1,10 @@
 const config = require('../../../knexfile').asyncworker
 const knex = require('knex')(config)
-const tasksEnum = require('../../constants/tasks-enum')
 const statusEnum = require('../../constants/status-enum')
 
-module.exports = function (reference, eligibilityId, claimId) {
+module.exports = function (reference, eligibilityId, claimId, taskType) {
   var task = {
-    'Task': tasksEnum.DWP_CHECK,
+    'Task': taskType,
     'Reference': reference,
     'EligibilityId': eligibilityId,
     'ClaimId': claimId,

--- a/app/services/workers/complete-claim.js
+++ b/app/services/workers/complete-claim.js
@@ -4,7 +4,8 @@ const getAllClaimData = require('../data/get-all-claim-data')
 const copyClaimDataToInternal = require('../data/copy-claim-data-to-internal')
 const deleteClaimFromExternal = require('../data/delete-claim-from-external')
 const autoApprovalProcess = require('../auto-approval/auto-approval-process')
-const insertTaskDwpCheck = require('../data/insert-task-dwp-check')
+const insertTask = require('../data/insert-task')
+const tasksEnum = require('../../constants/tasks-enum')
 
 module.exports.execute = function (task) {
   var reference = task.reference
@@ -19,5 +20,5 @@ module.exports.execute = function (task) {
     })
     .then(function () { return deleteClaimFromExternal(eligibilityId, claimId) })
     .then(function () { return autoApprovalProcess(claimData) })
-    .then(function () { return insertTaskDwpCheck(reference, eligibilityId, claimId) })
+    .then(function () { return insertTask(reference, eligibilityId, claimId, tasksEnum.DWP_CHECK) })
 }

--- a/test/integration/services/data/test-copy-claim-data-to-internal.js
+++ b/test/integration/services/data/test-copy-claim-data-to-internal.js
@@ -61,12 +61,6 @@ describe('services/data/copy-claim-data-to-internal', function () {
               })
           })
       })
-      .catch(function (error) {
-        return knex('IntSchema.Eligibility').select().then(function (result) {
-          console.dir(result)
-          throw error
-        })
-      })
     })
 
     it('should change claim status to PENDING if documents not uploaded', function () {

--- a/test/integration/services/data/test-insert-task-dwp-check.js
+++ b/test/integration/services/data/test-insert-task-dwp-check.js
@@ -4,15 +4,15 @@ const knex = require('knex')(config)
 const tasksEnum = require('../../../../app/constants/tasks-enum')
 const statusEnum = require('../../../../app/constants/status-enum')
 
-const insertTaskDwpCheck = require('../../../../app/services/data/insert-task-dwp-check')
+const insertTask = require('../../../../app/services/data/insert-task')
 
 const reference = 'DWPTASK'
 const eligibilityId = '4321'
 const claimId = '1234'
 
-describe('services/data/insert-task-dwp-check', function () {
-  it('should create Task with Reference, ClaimId, Status', function () {
-    return insertTaskDwpCheck(reference, eligibilityId, claimId)
+describe('services/data/insert-task', function () {
+  it('should create Task with Reference, ClaimId, Status and TaskType', function () {
+    return insertTask(reference, eligibilityId, claimId, tasksEnum.DWP_CHECK)
       .then(function () {
         return knex.table('IntSchema.Task')
           .where({'Reference': reference, 'EligibilityId': eligibilityId, 'ClaimId': claimId, 'Task': tasksEnum.DWP_CHECK})

--- a/test/unit/services/auto-approval/test-auto-approval-process.js
+++ b/test/unit/services/auto-approval/test-auto-approval-process.js
@@ -1,5 +1,7 @@
+const expect = require('chai').expect
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
+const statusEnum = require('../../../../app/constants/status-enum')
 require('sinon-bluebird')
 
 const testHelper = require('../../../test-helper')
@@ -41,6 +43,14 @@ var autoApprovalChecks = {
 var autoApprovalProcess = proxyquire('../../../../app/services/auto-approval/auto-approval-process', autoApprovalChecks)
 
 describe('services/auto-approval/checks/auto-approval-process', function () {
+  it('should return claimApproved false for PENDING claim', function () {
+    var pendingData = {Claim: {Status: statusEnum.PENDING}}
+    return autoApprovalProcess(pendingData)
+      .then(function (result) {
+        expect(result.claimApproved, 'should reject PENDING claims for auto-approval').to.be.false
+      })
+  })
+
   it('should call all relevant functions to retrieve auto approval data and perform checks', function () {
     return autoApprovalProcess(validAutoApprovalData)
       .then(function (result) {
@@ -51,7 +61,6 @@ describe('services/auto-approval/checks/auto-approval-process', function () {
 
           var key = Object.keys(autoApprovalChecks)[i]
           var stub = autoApprovalChecks[key]
-          console.dir(stub)
 
           sinon.assert.calledWith(stub, validAutoApprovalData)
         }

--- a/test/unit/services/auto-approval/test-auto-approval-process.js
+++ b/test/unit/services/auto-approval/test-auto-approval-process.js
@@ -11,22 +11,50 @@ var validAutoApprovalData = testHelper.getAutoApprovalData(reference1)
 var validCheckResult = new AutoApprovalCheckResult('', true, '')
 
 var getDataForAutoApprovalCheckStub = sinon.stub().resolves(validAutoApprovalData)
+var areChildrenUnder18Stub = sinon.stub().resolves(validCheckResult)
+var costAndVarianceEqualOrLessThanFirstTimeClaimStub = sinon.stub().resolves(validCheckResult)
+var doExpensesMatchFirstTimeClaimStub = sinon.stub().resolves(validCheckResult)
+var hasClaimedLessThanMaxTimesThisYearStub = sinon.stub().resolves(validCheckResult)
+var hasUploadedPrisonVisitConfirmationAndReceiptsStub = sinon.stub().resolves(validCheckResult)
+var isClaimSubmittedWithinTimeLimitStub = sinon.stub().resolves(validCheckResult)
+var isClaimTotalUnderLimitStub = sinon.stub().resolves(validCheckResult)
 var isLatestManualClaimApprovedStub = sinon.stub().resolves(validCheckResult)
 var isNoPreviousPendingClaimStub = sinon.stub().resolves(validCheckResult)
+var isVisitInPastStub = sinon.stub().resolves(validCheckResult)
+var visitDateDifferentToPreviousClaimsStub = sinon.stub().resolves(validCheckResult)
 
-var autoApprovalCheck = proxyquire('../../../../app/services/auto-approval/auto-approval-process', {
+var autoApprovalChecks = {
   '../data/get-data-for-auto-approval-check': getDataForAutoApprovalCheckStub,
+  './checks/are-children-under-18': areChildrenUnder18Stub,
+  './checks/cost-and-variance-equal-or-less-than-first-time-claim': costAndVarianceEqualOrLessThanFirstTimeClaimStub,
+  './checks/do-expenses-match-first-time-claim': doExpensesMatchFirstTimeClaimStub,
+  './checks/has-claimed-less-than-max-times-this-year': hasClaimedLessThanMaxTimesThisYearStub,
+  './checks/has-uploaded-prison-visit-confirmation-and-receipts': hasUploadedPrisonVisitConfirmationAndReceiptsStub,
+  './checks/is-claim-submitted-within-time-limit': isClaimSubmittedWithinTimeLimitStub,
+  './checks/is-claim-total-under-limit': isClaimTotalUnderLimitStub,
   './checks/is-latest-manual-claim-approved': isLatestManualClaimApprovedStub,
-  './checks/is-no-previous-pending-claim': isNoPreviousPendingClaimStub
-})
+  './checks/is-no-previous-pending-claim': isNoPreviousPendingClaimStub,
+  './checks/is-visit-in-past': isVisitInPastStub,
+  './checks/visit-date-different-to-previous-claims': visitDateDifferentToPreviousClaimsStub
+}
+
+var autoApprovalProcess = proxyquire('../../../../app/services/auto-approval/auto-approval-process', autoApprovalChecks)
 
 describe('services/auto-approval/checks/auto-approval-process', function () {
   it('should call all relevant functions to retrieve auto approval data and perform checks', function () {
-    return autoApprovalCheck(validAutoApprovalData)
+    return autoApprovalProcess(validAutoApprovalData)
       .then(function (result) {
         sinon.assert.calledOnce(getDataForAutoApprovalCheckStub)
-        sinon.assert.calledWith(isLatestManualClaimApprovedStub, validAutoApprovalData)
-        sinon.assert.calledWith(isNoPreviousPendingClaimStub, validAutoApprovalData)
+        for (var i = 0; i < Object.keys(autoApprovalChecks).length; i++) {
+          // skip check for getDataForAutoApproval, this is done above
+          if (i === 0) continue
+
+          var key = Object.keys(autoApprovalChecks)[i]
+          var stub = autoApprovalChecks[key]
+          console.dir(stub)
+
+          sinon.assert.calledWith(stub, validAutoApprovalData)
+        }
       })
   })
 })

--- a/test/unit/services/workers/test-complete-claim.js
+++ b/test/unit/services/workers/test-complete-claim.js
@@ -3,6 +3,8 @@ const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 require('sinon-bluebird')
 
+const taskEnum = require('../../../../app/constants/tasks-enum')
+
 const reference = '1234567'
 const eligibilityId = '1234'
 const claimId = 123
@@ -19,14 +21,14 @@ var getAllClaimData = sinon.stub().resolves(firstTimeClaimData)
 var copyClaimDataToInternal = sinon.stub().resolves()
 var deleteClaimFromExternal = sinon.stub().resolves()
 var autoApprovalProcess = sinon.stub().resolves()
-var insertTaskDwpCheck = sinon.stub().resolves()
+var insertTask = sinon.stub().resolves()
 
 const completeClaim = proxyquire('../../../../app/services/workers/complete-claim', {
   '../data/get-all-claim-data': getAllClaimData,
   '../data/copy-claim-data-to-internal': copyClaimDataToInternal,
   '../data/delete-claim-from-external': deleteClaimFromExternal,
   '../auto-approval/auto-approval-process': autoApprovalProcess,
-  '../data/insert-task-dwp-check': insertTaskDwpCheck
+  '../data/insert-task': insertTask
 })
 
 describe('services/workers/complete-claim', function () {
@@ -40,7 +42,7 @@ describe('services/workers/complete-claim', function () {
       expect(copyClaimDataToInternal.calledWith(firstTimeClaimData)).to.be.true
       expect(deleteClaimFromExternal.calledWith(eligibilityId, claimId)).to.be.true
       expect(autoApprovalProcess.calledWith(firstTimeClaimData)).to.be.true
-      expect(insertTaskDwpCheck.calledWith(reference, eligibilityId, claimId)).to.be.true
+      expect(insertTask.calledWith(reference, eligibilityId, claimId, taskEnum.DWP_CHECK)).to.be.true
     })
   })
 })


### PR DESCRIPTION
- Added call to create task to send accepted claim notification when a claim is auto-approved.  

- Added in code to use all implemented checks in auto-approval process.

- Refactored insert-task-dwp-check to be generic.  Now accepts a task type parameter.

- Refactored code that uses insert-task-dwp-check to use generic insert-task

- Refactored insert-task-dwp-check tests

- Refactored auto-approval-process test so it should be easier to modify when adding new tests

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards
- [ ] Error Handling
