### PR TITLE
Feature/apvs 365/prison location check

### DIFF
--- a/app/constants/guernsey-jersey-prisons-enum.js
+++ b/app/constants/guernsey-jersey-prisons-enum.js
@@ -1,0 +1,8 @@
+module.exports = {
+  LES_NICOLLES: {
+    value: 'les-nicolles'
+  },
+  HM_PRISON_LA_MOYE: {
+    value: 'hm-prison-la-moye'
+  }
+}

--- a/app/constants/helpers/enum-helper.js
+++ b/app/constants/helpers/enum-helper.js
@@ -1,0 +1,10 @@
+module.exports.getKeyByValue = function (enumeration, value) {
+  var result = null
+  Object.keys(enumeration).forEach(function (key) {
+    var element = enumeration[key]
+    if (typeof element === 'object' && element.value === value) {
+      result = element
+    }
+  })
+  return result
+}

--- a/app/services/auto-approval/auto-approval-process.js
+++ b/app/services/auto-approval/auto-approval-process.js
@@ -14,6 +14,7 @@ const autoApprovalChecks = [
   require('./checks/is-claim-total-under-limit'),
   require('./checks/is-latest-manual-claim-approved'),
   require('./checks/is-no-previous-pending-claim'),
+  require('./checks/is-prison-not-in-guernsey-jersey'),
   require('./checks/is-visit-in-past'),
   require('./checks/visit-date-different-to-previous-claims')
 ]

--- a/app/services/auto-approval/checks/is-prison-not-in-guernsey-jersey.js
+++ b/app/services/auto-approval/checks/is-prison-not-in-guernsey-jersey.js
@@ -1,0 +1,16 @@
+const AutoApprovalCheckResult = require('../../domain/auto-approval-check-result')
+const enumHelper = require('../../../constants/helpers/enum-helper')
+const guernseyJerseyPrisonsEnum = require('../../../constants/guernsey-jersey-prisons-enum')
+
+const CHECK_NAME = 'is-prison-not-in-guernsey-jersey'
+const FAILURE_MESSAGE = 'The prison being visited by this claimant is located in either Guernsey or Jersey'
+
+module.exports = function (autoApprovalData) {
+  var prisonName = autoApprovalData.Prisoner.PrisonName
+
+  if (enumHelper.getKeyByValue(guernseyJerseyPrisonsEnum, prisonName) == null) {
+    return new AutoApprovalCheckResult(CHECK_NAME, true, '')
+  } else {
+    return new AutoApprovalCheckResult(CHECK_NAME, false, FAILURE_MESSAGE)
+  }
+}

--- a/test/unit/services/auto-approval/test-auto-approval-process.js
+++ b/test/unit/services/auto-approval/test-auto-approval-process.js
@@ -24,6 +24,7 @@ var isClaimSubmittedWithinTimeLimitStub = sinon.stub().resolves(validCheckResult
 var isClaimTotalUnderLimitStub = sinon.stub().resolves(validCheckResult)
 var isLatestManualClaimApprovedStub = sinon.stub().resolves(validCheckResult)
 var isNoPreviousPendingClaimStub = sinon.stub().resolves(validCheckResult)
+var isPrisonNotInGuernseyJerseyStub = sinon.stub().resolves(validCheckResult)
 var isVisitInPastStub = sinon.stub().resolves(validCheckResult)
 var visitDateDifferentToPreviousClaimsStub = sinon.stub().resolves(validCheckResult)
 
@@ -38,6 +39,7 @@ var validAutoApprovalChecks = {
   './checks/is-claim-submitted-within-time-limit': isClaimSubmittedWithinTimeLimitStub,
   './checks/is-claim-total-under-limit': isClaimTotalUnderLimitStub,
   './checks/is-latest-manual-claim-approved': isLatestManualClaimApprovedStub,
+  './checks/is-prison-not-in-guernsey-jersey': isPrisonNotInGuernseyJerseyStub,
   './checks/is-no-previous-pending-claim': isNoPreviousPendingClaimStub,
   './checks/is-visit-in-past': isVisitInPastStub,
   './checks/visit-date-different-to-previous-claims': visitDateDifferentToPreviousClaimsStub

--- a/test/unit/services/auto-approval/test-is-prison-not-in-guernsey-jersey.js
+++ b/test/unit/services/auto-approval/test-is-prison-not-in-guernsey-jersey.js
@@ -1,0 +1,27 @@
+const expect = require('chai').expect
+const guernseyJerseyPrisonsEnum = require('../../../../app/constants/guernsey-jersey-prisons-enum')
+const isPrisonNotInGuernseyJersey = require('../../../../app/services/auto-approval/checks/is-prison-not-in-guernsey-jersey')
+
+var validAutoApprovalData = {
+  Prisoner: {
+    PrisonName: 'hewell'
+  }
+}
+
+var invalidAutoApprovalData = {
+  Prisoner: {
+    PrisonName: guernseyJerseyPrisonsEnum.LES_NICOLLES.value
+  }
+}
+
+describe('services/auto-approval/checks/is-prison-not-in-guernsey-jersey', function () {
+  it('should return true if the prison is outside Guernsey/Jersey', function () {
+    var check = isPrisonNotInGuernseyJersey(validAutoApprovalData)
+    expect(check.result).to.equal(true)
+  })
+
+  it('should return false if the prison is in Guernsey/Jersey', function () {
+    var check = isPrisonNotInGuernseyJersey(invalidAutoApprovalData)
+    expect(check.result).to.equal(false)
+  })
+})


### PR DESCRIPTION
- Added logic to auto-approval process to check that prison location is not in Guernsey/Jersey.

- Added enum that contains data about all prisons in Guernsey/Jersey.

- Added enum-helper from apvs-internal-web

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards
- [ ] Error Handling

