### PR TITLE
apvs-367 - cleanup old payment files

### DIFF
--- a/app/services/data/get-old-payment-files.js
+++ b/app/services/data/get-old-payment-files.js
@@ -1,0 +1,13 @@
+const knexConfig = require('../../../knexfile').asyncworker
+const knex = require('knex')(knexConfig)
+const config = require('../../../config')
+const moment = require('moment')
+
+const numberOfDays = config.PAYMENT_CLEANUP_FILE_NUMBER_OF_DAYS
+const cleanupDate = moment().subtract(numberOfDays, 'days')
+
+module.exports = function () {
+  return knex('IntSchema.DirectPaymentFile')
+    .where('DateCreated', '<', cleanupDate.toDate())
+    .where('IsEnabled', 'true')
+}

--- a/app/services/data/update-old-payment-files-is-enabled-false.js
+++ b/app/services/data/update-old-payment-files-is-enabled-false.js
@@ -1,0 +1,8 @@
+const config = require('../../../knexfile').asyncworker
+const knex = require('knex')(config)
+
+module.exports = function (oldPaymentIds) {
+  return knex('IntSchema.DirectPaymentFile')
+    .whereIn('PaymentFileId', oldPaymentIds)
+    .update('IsEnabled', 'false')
+}

--- a/app/services/direct-payments/delete-old-payment-files.js
+++ b/app/services/direct-payments/delete-old-payment-files.js
@@ -1,0 +1,10 @@
+const Promise = require('bluebird')
+// const unlink = require('fs').unlink
+const unlink = Promise.promisify(require('fs').unlink)
+
+module.exports = function (oldPaymentFiles) {
+  oldPaymentFiles.forEach(function (paymentFile) {
+    return unlink(paymentFile.Filepath)
+  })
+  return Promise.resolve()
+}

--- a/app/services/workers/cleanup-old-payment-files.js
+++ b/app/services/workers/cleanup-old-payment-files.js
@@ -1,0 +1,17 @@
+const deleteOldPaymentFiles = require('../direct-payments/delete-old-payment-files')
+const getOldPaymentFiles = require('../data/get-old-payment-files')
+const updateOldPaymentFilesIsEnabledFalse = require('../data/update-old-payment-files-is-enabled-false')
+
+module.exports.execute = function () {
+  var oldPaymentIds
+  return getOldPaymentFiles()
+    .then(function (oldPaymentFiles) {
+      if (oldPaymentFiles.length > 0) {
+        oldPaymentIds = oldPaymentFiles.map(function (file) { return file.id })
+        return deleteOldPaymentFiles(oldPaymentFiles)
+          .then(function () {
+            return updateOldPaymentFilesIsEnabledFalse(oldPaymentIds)
+          })
+      }
+    })
+}

--- a/config.js
+++ b/config.js
@@ -41,6 +41,7 @@ module.exports = {
   // Payment Generation
   PAYMENT_GENERATION_CRON: process.env.APVS_PAYMENT_GENERATION_CRON || '* 10 * * * * *',
   PAYMENT_FILE_PATH: process.env.APVS_PAYMENT_FILE_PATH || 'payments',
+  PAYMENT_CLEANUP_FILE_NUMBER_OF_DAYS: process.env.PAYMENT_CLEANUP_FILE_NUMBER_OF_DAYS || '28',
 
   // Auto approval configuration
   AUTO_APPROVAL_COST_VARIANCE_PERCENTAGE: process.env.APVS_AUTO_APPROVAL_COST_VARIANCE_PERCENTAGE || '0.1',

--- a/test/integration/services/data/test-get-old-payment-files.js
+++ b/test/integration/services/data/test-get-old-payment-files.js
@@ -1,0 +1,45 @@
+const config = require('../../../../knexfile').asyncworker
+const knex = require('knex')(config)
+const moment = require('moment')
+const expect = require('chai').expect
+const getOldPaymentFiles = require('../../../../app/services/data/get-old-payment-files')
+
+const OLD_FILE_DATE = moment().subtract('40', 'days')
+
+describe('services/data/get-old-payment-files', function () {
+  var paymentFileIds
+
+  before(function () {
+    return knex('IntSchema.DirectPaymentFile')
+      .insert([
+        {
+          FileType: 'TEST_FILE',
+          DateCreated: OLD_FILE_DATE.toDate(),
+          Filepath: 'test-file-path/testfile1.csv',
+          IsEnabled: 'true'
+        },
+        {
+          FileType: 'TEST_FILE',
+          DateCreated: OLD_FILE_DATE.toDate(),
+          Filepath: 'test-file-path/testfile2.csv',
+          IsEnabled: 'true'
+        }
+      ])
+      .returning('PaymentFileId')
+      .then(function (insertedIds) {
+        paymentFileIds = insertedIds
+      })
+  })
+
+  it('should retrieve inserted payment files', function () {
+    return getOldPaymentFiles()
+      .then(function (results) {
+        // Find files that were inserted
+        var testFiles = results.filter(function (result) {
+          return paymentFileIds.indexOf(result.PaymentFileId) !== -1
+        })
+
+        expect(testFiles.length).to.equal(2)
+      })
+  })
+})

--- a/test/integration/services/direct-payments/test-delete-old-payment-files.js
+++ b/test/integration/services/direct-payments/test-delete-old-payment-files.js
@@ -1,0 +1,26 @@
+const Promise = require('bluebird')
+const expect = require('chai').expect
+const deleteOldPaymentFiles = require('../../../../app/services/direct-payments/delete-old-payment-files')
+const writeFile = Promise.promisify(require('fs').writeFile)
+const fs = require('fs')
+
+const TEST_FILE_PATH = 'test.csv'
+const PAYMENT_FILE = { 'Filepath': TEST_FILE_PATH }
+
+describe('services/direct-payments/delete-old-payment-files', function () {
+  before(function () {
+    writeFile(TEST_FILE_PATH, 'test file contents\n')
+  })
+
+  it('should delete test payment files', function (done) {
+    deleteOldPaymentFiles([PAYMENT_FILE])
+      .then(function () {
+        fs.stat(TEST_FILE_PATH, function (err, stat) {
+           // file should not exist
+          expect(err.code).to.equal('ENOENT')
+          expect(stat).to.be.undefined
+          done()
+        })
+      })
+  })
+})


### PR DESCRIPTION
apvs-367 - cleanup old payment files
 
Worker, direct-payments and data functions to cleanup old payment files

Cleanup includes settings `IsEnabled` to false in `DirectPaymentFile` and deleting the associated file.

## Checklist

- [ ] Unit tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated

