### PR TITLE
Chore/fix approved cost on email

### DIFF
--- a/app/services/data/auto-approve-claim-expenses.js
+++ b/app/services/data/auto-approve-claim-expenses.js
@@ -24,7 +24,7 @@ function getClaimExpenses (claimId) {
 function updateClaimExpenseToApproved (claimExpense) {
   var updatedClaimExpense = {
     Status: statusEnum.APPROVED,
-    ApprovedCost: claimExpense.Cost
+    ApprovedCost: parseFloat(claimExpense.Cost).toFixed(2)
   }
 
   return knex('IntSchema.ClaimExpense')

--- a/app/services/notify/helpers/get-approved-claim-details-string.js
+++ b/app/services/notify/helpers/get-approved-claim-details-string.js
@@ -17,7 +17,7 @@ module.exports = function (claims) {
 
     result.push(claimHeader)
     result.push(`Claimed: £${claim.Cost.toFixed(2)}`)
-    result.push(`Approved: £${(claim.ApprovedCost || 0).toFixed(2)}`)
+    result.push(`Approved: £${(claim.ApprovedCost ? claim.ApprovedCost.toFixed(2) : (0).toFixed(2))}`)
     result.push(newLine)
   })
 


### PR DESCRIPTION
- Approved cost for claim expenses should be correctly set to 2 decimal places when a claim is auto-approved