### PR TITLE
Chore/auto approval claim same day

### DIFF
--- a/app/services/data/auto-approve-claim.js
+++ b/app/services/data/auto-approve-claim.js
@@ -1,5 +1,6 @@
 const config = require('../../../knexfile').asyncworker
 const knex = require('knex')(config)
+const moment = require('moment')
 
 const autoApproveClaimExpenses = require('./auto-approve-claim-expenses')
 const insertTask = require('../data/insert-task')
@@ -31,5 +32,5 @@ function getClaim (claimId) {
 function setClaimStatusToAutoApproved (claim) {
   return knex('IntSchema.Claim')
     .where('ClaimId', claim.ClaimId)
-    .update('Status', statusEnum.AUTOAPPROVED)
+    .update({'Status': statusEnum.AUTOAPPROVED, 'DateReviewed': moment().toDate()})
 }

--- a/app/services/data/get-data-for-auto-approval-check.js
+++ b/app/services/data/get-data-for-auto-approval-check.js
@@ -81,11 +81,15 @@ function getLatestManuallyApprovedClaim (previousClaims) {
 
     result = latestManuallyApprovedClaim
 
-    return getClaimExpenses(latestManuallyApprovedClaim.ClaimId)
-      .then(function (latestManuallyApprovedClaimExpenses) {
-        result.claimExpenses = latestManuallyApprovedClaimExpenses
-        return result
-      })
+    if (latestManuallyApprovedClaim) {
+      return getClaimExpenses(latestManuallyApprovedClaim.ClaimId)
+        .then(function (latestManuallyApprovedClaimExpenses) {
+          result.claimExpenses = latestManuallyApprovedClaimExpenses
+          return result
+        })
+    } else {
+      return Promise.resolve(null)
+    }
   } else {
     return Promise.resolve(null)
   }

--- a/app/services/data/get-data-for-auto-approval-check.js
+++ b/app/services/data/get-data-for-auto-approval-check.js
@@ -62,11 +62,20 @@ function getPreviousClaims (claimId, eligibilityId, dateOfVisit) {
 function getLatestManuallyApprovedClaim (previousClaims) {
   if (previousClaims.length > 0) {
     var result = {}
-    var latestManuallyApprovedClaim = previousClaims[0]
+    var latestManuallyApprovedClaim = null
 
     previousClaims.forEach(function (previousClaim) {
-      if (previousClaim.Status === statusEnum.APPROVED && previousClaim.DateSubmitted < latestManuallyApprovedClaim.DateSubmitted) {
-        latestManuallyApprovedClaim = previousClaim
+      var previousClaimIsApproved = previousClaim.DateReviewed &&
+        previousClaim.Status === statusEnum.APPROVED
+
+      if (previousClaimIsApproved) {
+        if (!latestManuallyApprovedClaim) {
+          latestManuallyApprovedClaim = previousClaim
+        } else {
+          if (previousClaim.DateReviewed < latestManuallyApprovedClaim.DateReviewed) {
+            latestManuallyApprovedClaim = previousClaim
+          }
+        }
       }
     })
 

--- a/app/services/data/get-data-for-auto-approval-check.js
+++ b/app/services/data/get-data-for-auto-approval-check.js
@@ -55,9 +55,8 @@ function getDataFromInternal (claimId, eligibilityId, reference) {
 function getPreviousClaims (claimId, eligibilityId, dateOfVisit) {
   return knex('IntSchema.Claim')
     .where('EligibilityId', eligibilityId)
-    .andWhere('DateOfJourney', '<', dateOfVisit)
     .whereNot('ClaimId', claimId)
-    .orderBy('DateOfJourney', 'desc')
+    .orderBy('DateReviewed', 'desc')
 }
 
 function getLatestManuallyApprovedClaim (previousClaims) {

--- a/test/integration/services/data/test-get-data-for-auto-approval-check.js
+++ b/test/integration/services/data/test-get-data-for-auto-approval-check.js
@@ -19,9 +19,10 @@ describe('services/data/get-data-for-auto-approval-check', function () {
             ClaimId: uniqueId,
             EligibilityId: claimData.Claim.EligibilityId,
             Reference: reference,
-            DateOfJourney: moment().subtract(60, 'days').toDate(),
-            DateCreated: moment().subtract(50, 'days').toDate(),
-            DateSubmitted: moment().subtract(40, 'days').toDate(),
+            DateOfJourney: moment().subtract(80, 'days').toDate(),
+            DateCreated: moment().subtract(70, 'days').toDate(),
+            DateSubmitted: moment().subtract(60, 'days').toDate(),
+            DateReviewed: moment().subtract(50, 'days').toDate(),
             Status: 'APPROVED'
           }
         },
@@ -30,9 +31,22 @@ describe('services/data/get-data-for-auto-approval-check', function () {
             ClaimId: uniqueId + 1,
             EligibilityId: claimData.Claim.EligibilityId,
             Reference: reference,
-            DateOfJourney: moment().subtract(90, 'days').toDate(),
-            DateCreated: moment().subtract(80, 'days').toDate(),
-            DateSubmitted: moment().subtract(70, 'days').toDate(),
+            DateOfJourney: moment().subtract(60, 'days').toDate(),
+            DateCreated: moment().subtract(50, 'days').toDate(),
+            DateSubmitted: moment().subtract(40, 'days').toDate(),
+            DateReviewed: moment().subtract(30, 'days').toDate(),
+            Status: 'REJECTED'
+          }
+        },
+        {
+          Claim: {
+            ClaimId: uniqueId + 2,
+            EligibilityId: claimData.Claim.EligibilityId,
+            Reference: reference,
+            DateOfJourney: moment().subtract(100, 'days').toDate(),
+            DateCreated: moment().subtract(90, 'days').toDate(),
+            DateSubmitted: moment().subtract(80, 'days').toDate(),
+            DateReviewed: moment().subtract(70, 'days').toDate(),
             Status: 'REJECTED'
           }
         }
@@ -52,7 +66,7 @@ describe('services/data/get-data-for-auto-approval-check', function () {
       .then(function (result) {
         expect(result.previousClaims).to.not.be.null
         expect(result.latestManuallyApprovedClaim).to.not.be.null
-        expect(result.latestManuallyApprovedClaim.ClaimId).to.equal(result.previousClaims[0].ClaimId)
+        expect(result.latestManuallyApprovedClaim.ClaimId).to.equal(result.previousClaims[1].ClaimId)
       })
   })
 

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -370,6 +370,7 @@ function getClaimObject (claimId, eligibilityId, reference, dateCreated, dateOfJ
     DateCreated: dateCreated,
     DateOfJourney: dateOfJourney,
     DateSubmitted: dateSubmitted,
+    DateReviewed: status === 'APPROVED' || status === 'AUTO-APPROVED' || status === 'REJECTED' || status === 'REQUEST_INFORMATION' ? moment().toDate() : null,
     Status: status
   }
 


### PR DESCRIPTION
- DateReviewed should now get set when a claim is auto approved
- Code to retrieve previous claims will now return all other claims associated to the claimant, regardless of date
- Logic to retrieve latest manually approved claim should now use DateReviewed to compare instead of DateOfJourney
- Updated test for get-data-for-auto-approval so that test data is in incorrect order
- Updated test-helper to populate DateReviewed if appropriate status is passed 

Closes issue #54 

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards