### PR TITLE
Chore/refactor get claims pending payment.js

### DIFF
--- a/app/services/data/get-claims-pending-payment.js
+++ b/app/services/data/get-claims-pending-payment.js
@@ -25,7 +25,6 @@ module.exports = function () {
     .whereNull('IntSchema.Claim.PaymentStatus')
     .groupBy(selectColumns)
     .then(function (results) {
-      console.dir(results)
       return _.map(results, record => {
         return [
           record.ClaimId,

--- a/test/integration/services/data/test-get-claims-pending-payment.js
+++ b/test/integration/services/data/test-get-claims-pending-payment.js
@@ -66,6 +66,6 @@ describe('services/data/get-claims-pending-payment', function () {
   })
 
   after(function () {
-    return testHelper.deleteAll(reference, 'IntSchema')
+    // return testHelper.deleteAll(reference, 'IntSchema')
   })
 })

--- a/test/integration/services/data/test-get-claims-pending-payment.js
+++ b/test/integration/services/data/test-get-claims-pending-payment.js
@@ -66,6 +66,6 @@ describe('services/data/get-claims-pending-payment', function () {
   })
 
   after(function () {
-    // return testHelper.deleteAll(reference, 'IntSchema')
+    return testHelper.deleteAll(reference, 'IntSchema')
   })
 })


### PR DESCRIPTION
Extracted logic to get deduction total into subquery instead of using sumDistinct.  This shouldn't have much of a performance impact as there should only ever be a low number of ClaimDeduction records associated with each claim.

Closes issue #85 