### PR TITLE
Feature/apvs 380/claimant trusted

### DIFF
--- a/app/constants/auto-approval-rules-enum.js
+++ b/app/constants/auto-approval-rules-enum.js
@@ -11,5 +11,6 @@ module.exports = [
   'is-no-previous-pending-claim',
   'is-prison-not-in-guernsey-jersey',
   'is-visit-in-past',
-  'visit-date-different-to-previous-claims'
+  'visit-date-different-to-previous-claims',
+  'is-claimant-trusted'
 ]

--- a/app/services/auto-approval/checks/is-claimant-trusted.js
+++ b/app/services/auto-approval/checks/is-claimant-trusted.js
@@ -4,7 +4,7 @@ const CHECK_NAME = 'is-claimant-trusted'
 const FAILURE_MESSAGE = 'This claimant has been marked as untrusted by a case worker'
 
 module.exports = function (autoApprovalData) {
-  var checkResult = autoApprovalData.Eligibility.IsUntrusted === false
+  var checkResult = autoApprovalData.Eligibility.IsTrusted === true
 
   return new AutoApprovalCheckResult(CHECK_NAME, checkResult, checkResult ? '' : FAILURE_MESSAGE)
 }

--- a/app/services/auto-approval/checks/is-claimant-trusted.js
+++ b/app/services/auto-approval/checks/is-claimant-trusted.js
@@ -1,0 +1,10 @@
+const AutoApprovalCheckResult = require('../../domain/auto-approval-check-result')
+
+const CHECK_NAME = 'is-claimant-trusted'
+const FAILURE_MESSAGE = 'This claimant has been marked as untrusted by a case worker'
+
+module.exports = function (autoApprovalData) {
+  var checkResult = autoApprovalData.Eligibility.IsUntrusted === false
+
+  return new AutoApprovalCheckResult(CHECK_NAME, checkResult, checkResult ? '' : FAILURE_MESSAGE)
+}

--- a/test/unit/services/auto-approval/checks/test-is-claimant-trusted.js
+++ b/test/unit/services/auto-approval/checks/test-is-claimant-trusted.js
@@ -1,0 +1,27 @@
+const expect = require('chai').expect
+
+const isClaimantTrusted = require('../../../../../app/services/auto-approval/checks/is-claimant-trusted')
+
+var autoApprovalDataTrusted = {
+  Eligibility: {
+    IsUntrusted: false
+  }
+}
+
+var autoApprovalDataUntrusted = {
+  Eligibility: {
+    IsUntrusted: true
+  }
+}
+
+describe('services/auto-approval/checks/is-claimant-trusted', function () {
+  it('should return true if claimant is marked as trusted', function () {
+    var checkResult = isClaimantTrusted(autoApprovalDataTrusted)
+    expect(checkResult.result).to.equal(true)
+  })
+
+  it('should return false if claimant is marked as untrusted', function () {
+    var checkResult = isClaimantTrusted(autoApprovalDataUntrusted)
+    expect(checkResult.result).to.equal(false)
+  })
+})

--- a/test/unit/services/auto-approval/checks/test-is-claimant-trusted.js
+++ b/test/unit/services/auto-approval/checks/test-is-claimant-trusted.js
@@ -4,13 +4,13 @@ const isClaimantTrusted = require('../../../../../app/services/auto-approval/che
 
 var autoApprovalDataTrusted = {
   Eligibility: {
-    IsUntrusted: false
+    IsTrusted: true
   }
 }
 
 var autoApprovalDataUntrusted = {
   Eligibility: {
-    IsUntrusted: true
+    IsTrusted: false
   }
 }
 


### PR DESCRIPTION
- Added is-claimant-trusted auto-approval check that will fail if the IsTrusted field on the claimants Eligibility record is false

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
