### PR TITLE
Chore/fix benefit document assoiciation with claim

### DIFF
--- a/app/services/data/delete-claim-from-external.js
+++ b/app/services/data/delete-claim-from-external.js
@@ -7,10 +7,10 @@ module.exports = function (eligibilityId, claimId) {
       return knex('ExtSchema.ClaimDocument').where('ClaimId', claimId).del()
     })
     .then(function () {
-      return knex('ExtSchema.ClaimExpense').where('ClaimId', claimId).del()
+      return knex('ExtSchema.ClaimDocument').where({'ClaimId': null, EligibilityId: eligibilityId}).del()
     })
     .then(function () {
-      return knex('ExtSchema.ClaimExpense').where({'ClaimId': null, EligibilityId: eligibilityId}).del()
+      return knex('ExtSchema.ClaimExpense').where('ClaimId', claimId).del()
     })
     .then(function () {
       return knex('ExtSchema.ClaimChild').where('ClaimId', claimId).del()

--- a/app/services/data/delete-claim-from-external.js
+++ b/app/services/data/delete-claim-from-external.js
@@ -10,6 +10,9 @@ module.exports = function (eligibilityId, claimId) {
       return knex('ExtSchema.ClaimExpense').where('ClaimId', claimId).del()
     })
     .then(function () {
+      return knex('ExtSchema.ClaimExpense').where({'ClaimId': null, EligibilityId: eligibilityId}).del()
+    })
+    .then(function () {
       return knex('ExtSchema.ClaimChild').where('ClaimId', claimId).del()
     })
     .then(function () {

--- a/app/services/data/delete-claim-from-external.js
+++ b/app/services/data/delete-claim-from-external.js
@@ -4,10 +4,9 @@ const knex = require('knex')(config)
 module.exports = function (eligibilityId, claimId) {
   return knex('ExtSchema.ClaimBankDetail').where('ClaimId', claimId).del()
     .then(function () {
-      return knex('ExtSchema.ClaimDocument').where('ClaimId', claimId).del()
-    })
-    .then(function () {
-      return knex('ExtSchema.ClaimDocument').where({'ClaimId': null, EligibilityId: eligibilityId}).del()
+      return knex('ExtSchema.ClaimDocument')
+        .where('ClaimId', claimId).del()
+        .orWhere({'ClaimId': null, EligibilityId: eligibilityId})
     })
     .then(function () {
       return knex('ExtSchema.ClaimExpense').where('ClaimId', claimId).del()

--- a/app/services/data/get-all-claim-data.js
+++ b/app/services/data/get-all-claim-data.js
@@ -9,7 +9,7 @@ module.exports = function (schema, reference, eligibilityId, claimId) {
     getClaim(schema, claimId),
     getClaimChildren(schema, claimId),
     getClaimExpenses(schema, claimId),
-    getClaimDocuments(schema, claimId),
+    getClaimDocuments(schema, reference, eligibilityId, claimId),
     getClaimBankDetail(schema, claimId),
     getEligibilityVisitorUpdateContactDetail(schema, reference, eligibilityId),
     getClaimEscort(schema, claimId)
@@ -57,8 +57,10 @@ function getClaimChildren (schema, claimId) {
   return knex(`${schema}.ClaimChild`).select().where({'ClaimId': claimId, 'IsEnabled': true})
 }
 
-function getClaimDocuments (schema, claimId) {
-  return knex(`${schema}.ClaimDocument`).select().where({'ClaimId': claimId, 'IsEnabled': true})
+function getClaimDocuments (schema, reference, eligibilityId, claimId) {
+  return knex(`${schema}.ClaimDocument`).select()
+    .where({'Reference': reference, 'EligibilityId': eligibilityId, 'ClaimId': claimId, 'IsEnabled': true})
+    .orWhere({'Reference': reference, 'EligibilityId': eligibilityId, 'ClaimId': null, 'IsEnabled': true})
 }
 
 function getClaimEscort (schema, claimId) {

--- a/app/services/data/get-claim-documents.js
+++ b/app/services/data/get-claim-documents.js
@@ -3,5 +3,6 @@ const knex = require('knex')(config)
 
 module.exports = function (schema, reference, eligibilityId, claimId) {
   return knex(`${schema}.ClaimDocument`)
-    .where({'Reference': reference, 'EligibilityId': eligibilityId, 'ClaimId': claimId, IsEnabled: true})
+    .where({'Reference': reference, 'EligibilityId': eligibilityId, 'ClaimId': claimId, 'IsEnabled': true})
+    .orWhere({'Reference': reference, 'EligibilityId': eligibilityId, 'ClaimId': null, 'IsEnabled': true})
 }

--- a/app/services/data/move-claim-documents-to-internal.js
+++ b/app/services/data/move-claim-documents-to-internal.js
@@ -41,7 +41,7 @@ function copyClaimDocumentsToInternal (claimDocuments) {
 
 function deleteClaimDocumentsFromExternal (reference, eligibilityId, claimId) {
   return knex('ExtSchema.ClaimDocument')
-    .where({'Reference': reference, 'EligibilityId': eligibilityId, 'ClaimId': claimId}).del()
+    .where({'Reference': reference, 'EligibilityId': eligibilityId}).del()
 }
 
 function matchOldInternalDocumentsToUpdatedDocuments (internalDocuments, updatedDocuments) {

--- a/test/integration/services/data/test-copy-claim-data-to-internal.js
+++ b/test/integration/services/data/test-copy-claim-data-to-internal.js
@@ -94,7 +94,7 @@ describe('services/data/copy-claim-data-to-internal', function () {
           .join('IntSchema.ClaimChild', 'IntSchema.Claim.ClaimId', '=', 'IntSchema.ClaimChild.ClaimId')
           .join('IntSchema.ClaimBankDetail', 'IntSchema.Claim.ClaimId', '=', 'IntSchema.ClaimBankDetail.ClaimId')
           .join('IntSchema.ClaimExpense', 'IntSchema.Claim.ClaimId', '=', 'IntSchema.ClaimExpense.ClaimId')
-          .join('IntSchema.ClaimDocument', 'IntSchema.Claim.ClaimId', '=', 'IntSchema.ClaimDocument.ClaimId')
+          .join('IntSchema.ClaimDocument', 'IntSchema.Claim.Reference', '=', 'IntSchema.ClaimDocument.Reference')
           .select()
           .then(function (results) {
             expect(results.length, 'Should have 8 rows, 2x child 2x expense x2 document').to.be.equal(8)

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -279,7 +279,7 @@ module.exports.getClaimData = function (reference) {
         ClaimDocumentId: uniqueId2,
         EligibilityId: uniqueId,
         Reference: reference,
-        ClaimId: uniqueId,
+        ClaimId: null,
         DocumentType: 'BENEFIT',
         ClaimExpenseId: null,
         DocumentStatus: 'uploaded',


### PR DESCRIPTION
Updated moves and deletes to us eligibility and reference and look for claimId being null which is the case when it is a benefit document
 
* Updated delete claim from external
* Updated get all claim data
* Updated get claim documents
* Updated move claim documents to internal
* Updated test helper to use accurate data to check for

## Checklist

- [x] Coding standards
