### PR TITLE
chore/fix-claim-event-on-no-note-on-claim-update

### DIFF
--- a/app/services/workers/request-information-response.js
+++ b/app/services/workers/request-information-response.js
@@ -43,7 +43,11 @@ function getStatusForUpdatedClaim (claimData) {
 }
 
 function insertClaimEventForNote (reference, eligibilityId, claimId, note) {
-  return insertClaimEvent(reference, eligibilityId, claimId, null, 'NEW-DOCUMENT-UPLOADED', null, note, false)
+  if (note) {
+    return insertClaimEvent(reference, eligibilityId, claimId, null, 'MESSAGE', null, note, false)
+  } else {
+    return Promise.resolve()
+  }
 }
 
 function insertClaimEventForUpdate (reference, eligibilityId, claimId, updatedDocuments) {


### PR DESCRIPTION
Added check for if note exists, if not no claim event. 

Issue https://github.com/ministryofjustice/apvs-external-web/issues/402

* Made check for if note exists
* Added test to cover both cases

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards