### PR TITLE
Added check to make sure current claim falls within current claimable year

### DIFF
--- a/app/services/auto-approval/checks/has-claimed-less-than-max-times-this-year.js
+++ b/app/services/auto-approval/checks/has-claimed-less-than-max-times-this-year.js
@@ -21,17 +21,18 @@ module.exports = function (autoApprovalData) {
 
   var startOfClaimableYear = now.subtract(monthsSinceStartOfClaimableYear, 'months')
     .subtract(daysSinceStartOfClaimableYear, 'days')
+  var endOfClaimableYear = startOfClaimableYear.clone().add('1', 'years')
 
-  var numberOfClaimsThisYear = getNumberOfClaimsSinceDate(autoApprovalData.previousClaims, autoApprovalData.Claim, startOfClaimableYear.toDate())
+  var numberOfClaimsThisYear = getNumberOfClaimsSinceDate(autoApprovalData.previousClaims, autoApprovalData.Claim, startOfClaimableYear.toDate(), endOfClaimableYear.toDate())
   var checkPassed = numberOfClaimsThisYear < autoApprovalData.maxNumberOfClaimsPerYear
 
   return new AutoApprovalCheckResult(CHECK_NAME, checkPassed, checkPassed ? '' : FAILURE_MESSAGE)
 }
 
-function getNumberOfClaimsSinceDate (previousClaims, currentClaim, date) {
+function getNumberOfClaimsSinceDate (previousClaims, currentClaim, date, cutOffDate) {
   var count = 0
 
-  if (currentClaim.DateOfJourney >= date) {
+  if (currentClaim.DateOfJourney >= date && currentClaim.DateOfJourney <= cutOffDate) {
     count++
   }
 

--- a/test/unit/services/auto-approval/checks/test-has-claimed-less-than-max-times-this-year.js
+++ b/test/unit/services/auto-approval/checks/test-has-claimed-less-than-max-times-this-year.js
@@ -36,6 +36,14 @@ describe('services/auto-approval/checks/has-claimed-less-than-max-times-this-yea
     var checkResult = hasClaimedLessThanMaxTimesThisYear(autoApprovalData)
     expect(checkResult.result).to.equal(true)
   })
+
+  it('should return true if the claimant has claimed the max number of claims this year, and submits an advance claim that falls outside the claimable year', function () {
+    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(26, now.clone().subtract(1, 'years'))
+    autoApprovalData.Claim.DateOfJourney = now.clone().add('20', 'days').toDate()
+
+    var checkResult = hasClaimedLessThanMaxTimesThisYear(autoApprovalData)
+    expect(checkResult.result).to.equal(true)
+  })
 })
 
 function generateAutoApprovalDataWithPreviousClaims (numberOfClaims, startDate) {


### PR DESCRIPTION
Resolves the issue where an advance claim can trigger the max claims per year validation, even if the claim being checked doesn't fall within the current claimable year.

See #134 for more info