### PR TITLE
Bug/fix max claims per month

### DIFF
--- a/app/services/auto-approval/checks/has-claimed-less-than-max-times-this-month.js
+++ b/app/services/auto-approval/checks/has-claimed-less-than-max-times-this-month.js
@@ -11,15 +11,20 @@ module.exports = function (autoApprovalData) {
   }
 
   var firstDayOfCurrentMonth = dateFormatter.now().startOf('month').toDate()
+  var firstDayOfNextMonth = dateFormatter.now().startOf('month').add('1', 'months').toDate()
 
-  var numberOfClaimsThisMonth = getCountOfApprovedClaimsSubmittedSinceDate(autoApprovalData.previousClaims, firstDayOfCurrentMonth)
+  var numberOfClaimsThisMonth = getCountOfApprovedClaimsSubmittedSinceDate(autoApprovalData.previousClaims, autoApprovalData.Claim, firstDayOfCurrentMonth, firstDayOfNextMonth)
   var checkPassed = numberOfClaimsThisMonth < autoApprovalData.maxNumberOfClaimsPerMonth
 
   return new AutoApprovalCheckResult(CHECK_NAME, checkPassed, checkPassed ? '' : FAILURE_MESSAGE)
 }
 
-function getCountOfApprovedClaimsSubmittedSinceDate (previousClaims, date) {
+function getCountOfApprovedClaimsSubmittedSinceDate (previousClaims, currentClaim, date, cutOffDate) {
   var count = 0
+
+  if (currentClaim.DateOfJourney >= date && currentClaim.DateOfJourney <= cutOffDate) {
+    count++
+  }
 
   var claims = previousClaims.filter(function (claim) {
     return claim.Status === claimStatusEnum.APPROVED ||

--- a/app/services/auto-approval/checks/has-claimed-less-than-max-times-this-month.js
+++ b/app/services/auto-approval/checks/has-claimed-less-than-max-times-this-month.js
@@ -14,7 +14,7 @@ module.exports = function (autoApprovalData) {
   var firstDayOfNextMonth = dateFormatter.now().startOf('month').add('1', 'months').toDate()
 
   var numberOfClaimsThisMonth = getCountOfApprovedClaimsSubmittedSinceDate(autoApprovalData.previousClaims, autoApprovalData.Claim, firstDayOfCurrentMonth, firstDayOfNextMonth)
-  var checkPassed = numberOfClaimsThisMonth < autoApprovalData.maxNumberOfClaimsPerMonth
+  var checkPassed = numberOfClaimsThisMonth <= autoApprovalData.maxNumberOfClaimsPerMonth
 
   return new AutoApprovalCheckResult(CHECK_NAME, checkPassed, checkPassed ? '' : FAILURE_MESSAGE)
 }

--- a/app/services/auto-approval/checks/has-claimed-less-than-max-times-this-year.js
+++ b/app/services/auto-approval/checks/has-claimed-less-than-max-times-this-year.js
@@ -24,7 +24,7 @@ module.exports = function (autoApprovalData) {
   var endOfClaimableYear = startOfClaimableYear.clone().add('1', 'years')
 
   var numberOfClaimsThisYear = getNumberOfClaimsSinceDate(autoApprovalData.previousClaims, autoApprovalData.Claim, startOfClaimableYear.toDate(), endOfClaimableYear.toDate())
-  var checkPassed = numberOfClaimsThisYear < autoApprovalData.maxNumberOfClaimsPerYear
+  var checkPassed = numberOfClaimsThisYear <= autoApprovalData.maxNumberOfClaimsPerYear
 
   return new AutoApprovalCheckResult(CHECK_NAME, checkPassed, checkPassed ? '' : FAILURE_MESSAGE)
 }

--- a/test/unit/services/auto-approval/checks/test-has-claimed-less-than-max-times-this-month.js
+++ b/test/unit/services/auto-approval/checks/test-has-claimed-less-than-max-times-this-month.js
@@ -9,30 +9,23 @@ const MAX_NUMBER_OF_CLAIMS_PER_MONTH = '4'
 describe('services/auto-approval/checks/has-claimed-less-than-max-times-this-month', function () {
   it(`should return false if the number of claims made for the current month is greater than ${MAX_NUMBER_OF_CLAIMS_PER_MONTH}`, function () {
     var firstOfCurrentMonth = dateFormatter.now().startOf('month')
-    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(10, firstOfCurrentMonth)
-    // Should be 5 APPROVED past claims
-    autoApprovalData.previousClaims = setClaimStatuses(autoApprovalData.previousClaims, 2, 'NEW')
+    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(5, firstOfCurrentMonth)
 
     var checkResult = hasClaimedLessThanMaxTimesThisMonth(autoApprovalData)
     expect(checkResult.result).to.equal(false)
   })
 
-  it(`should return false if the number of claims made for the current month is equal to ${MAX_NUMBER_OF_CLAIMS_PER_MONTH}`, function () {
+  it(`should return true if the number of claims made for the current month is equal to ${MAX_NUMBER_OF_CLAIMS_PER_MONTH}`, function () {
     var firstOfCurrentMonth = dateFormatter.now().startOf('month')
-    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(9, firstOfCurrentMonth)
-    // Should be 4 APPROVED past claims
-    autoApprovalData.previousClaims = setClaimStatuses(autoApprovalData.previousClaims, 2, 'NEW')
-    console.dir(autoApprovalData)
+    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(4, firstOfCurrentMonth)
 
     var checkResult = hasClaimedLessThanMaxTimesThisMonth(autoApprovalData)
-    expect(checkResult.result).to.equal(false)
+    expect(checkResult.result).to.equal(true)
   })
 
   it(`should return true if the number of claims made for the current month is less than ${MAX_NUMBER_OF_CLAIMS_PER_MONTH}`, function () {
     var firstOfCurrentMonth = dateFormatter.now().startOf('month')
-    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(8, firstOfCurrentMonth)
-    // Should be 3 APPROVED past claims
-    autoApprovalData = setClaimStatuses(autoApprovalData.previousClaims, 2, 'NEW')
+    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(3, firstOfCurrentMonth)
 
     var checkResult = hasClaimedLessThanMaxTimesThisMonth(autoApprovalData)
     expect(checkResult.result).to.equal(true)
@@ -49,7 +42,7 @@ describe('services/auto-approval/checks/has-claimed-less-than-max-times-this-mon
   it('should return true if the claimant has claimed the max number of claims this month, and submits an advance claim that falls outside the claimable month', function () {
     var firstOfCurrentMonth = dateFormatter.now().startOf('month')
     var secondOfNextMonth = dateFormatter.now().startOf('month').add('1', 'months').add('1', 'days')
-    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(MAX_NUMBER_OF_CLAIMS_PER_MONTH, firstOfCurrentMonth)
+    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(4, firstOfCurrentMonth)
     autoApprovalData.Claim.DateOfJourney = secondOfNextMonth.toDate()
 
     var checkResult = hasClaimedLessThanMaxTimesThisMonth(autoApprovalData)
@@ -58,10 +51,11 @@ describe('services/auto-approval/checks/has-claimed-less-than-max-times-this-mon
 })
 
 function generateAutoApprovalDataWithPreviousClaims (numberOfClaims, startDate) {
+  var firstOfCurrentMonth = dateFormatter.now().startOf('month')
   var now = dateFormatter.now()
   var result = {
     Claim: {
-      DateOfJourney: now.clone().subtract('14', 'days').toDate()
+      DateOfJourney: firstOfCurrentMonth.clone().toDate()
     },
     previousClaims: [],
     maxNumberOfClaimsPerMonth: MAX_NUMBER_OF_CLAIMS_PER_MONTH
@@ -81,14 +75,4 @@ function generateAutoApprovalDataWithPreviousClaims (numberOfClaims, startDate) 
   }
 
   return result
-}
-
-function setClaimStatuses (claims, frequency, status) {
-  for (var i = 0; i < claims.length; i++) {
-    if (i % frequency === 0) {
-      claims[i].Status = status
-    }
-  }
-
-  return claims
 }

--- a/test/unit/services/auto-approval/checks/test-has-claimed-less-than-max-times-this-month.js
+++ b/test/unit/services/auto-approval/checks/test-has-claimed-less-than-max-times-this-month.js
@@ -9,8 +9,20 @@ const MAX_NUMBER_OF_CLAIMS_PER_MONTH = '4'
 describe('services/auto-approval/checks/has-claimed-less-than-max-times-this-month', function () {
   it(`should return false if the number of claims made for the current month is greater than ${MAX_NUMBER_OF_CLAIMS_PER_MONTH}`, function () {
     var firstOfCurrentMonth = dateFormatter.now().startOf('month')
-    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(8, firstOfCurrentMonth)
+    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(10, firstOfCurrentMonth)
+    // Should be 5 APPROVED past claims
     autoApprovalData.previousClaims = setClaimStatuses(autoApprovalData.previousClaims, 2, 'NEW')
+
+    var checkResult = hasClaimedLessThanMaxTimesThisMonth(autoApprovalData)
+    expect(checkResult.result).to.equal(false)
+  })
+
+  it(`should return false if the number of claims made for the current month is equal to ${MAX_NUMBER_OF_CLAIMS_PER_MONTH}`, function () {
+    var firstOfCurrentMonth = dateFormatter.now().startOf('month')
+    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(9, firstOfCurrentMonth)
+    // Should be 4 APPROVED past claims
+    autoApprovalData.previousClaims = setClaimStatuses(autoApprovalData.previousClaims, 2, 'NEW')
+    console.dir(autoApprovalData)
 
     var checkResult = hasClaimedLessThanMaxTimesThisMonth(autoApprovalData)
     expect(checkResult.result).to.equal(false)
@@ -18,7 +30,8 @@ describe('services/auto-approval/checks/has-claimed-less-than-max-times-this-mon
 
   it(`should return true if the number of claims made for the current month is less than ${MAX_NUMBER_OF_CLAIMS_PER_MONTH}`, function () {
     var firstOfCurrentMonth = dateFormatter.now().startOf('month')
-    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(6, firstOfCurrentMonth)
+    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(8, firstOfCurrentMonth)
+    // Should be 3 APPROVED past claims
     autoApprovalData = setClaimStatuses(autoApprovalData.previousClaims, 2, 'NEW')
 
     var checkResult = hasClaimedLessThanMaxTimesThisMonth(autoApprovalData)
@@ -32,18 +45,32 @@ describe('services/auto-approval/checks/has-claimed-less-than-max-times-this-mon
     var checkResult = hasClaimedLessThanMaxTimesThisMonth(autoApprovalData)
     expect(checkResult.result).to.equal(true)
   })
+
+  it('should return true if the claimant has claimed the max number of claims this month, and submits an advance claim that falls outside the claimable month', function () {
+    var firstOfCurrentMonth = dateFormatter.now().startOf('month')
+    var secondOfNextMonth = dateFormatter.now().startOf('month').add('1', 'months').add('1', 'days')
+    var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(MAX_NUMBER_OF_CLAIMS_PER_MONTH, firstOfCurrentMonth)
+    autoApprovalData.Claim.DateOfJourney = secondOfNextMonth.toDate()
+
+    var checkResult = hasClaimedLessThanMaxTimesThisMonth(autoApprovalData)
+    expect(checkResult.result).to.equal(true)
+  })
 })
 
 function generateAutoApprovalDataWithPreviousClaims (numberOfClaims, startDate) {
+  var now = dateFormatter.now()
   var result = {
+    Claim: {
+      DateOfJourney: now.clone().subtract('14', 'days').toDate()
+    },
     previousClaims: [],
     maxNumberOfClaimsPerMonth: MAX_NUMBER_OF_CLAIMS_PER_MONTH
   }
-  var now = dateFormatter.now()
+
   var durationSinceStartDate = now.diff(startDate, 'days')
   var daysBetweenClaims = Math.floor(durationSinceStartDate / numberOfClaims)
 
-  for (var i = 0; i < numberOfClaims; i++) {
+  for (var i = 0; i < numberOfClaims - 1; i++) {
     var claim = {
       ClaimId: initialClaimId + i,
       DateSubmitted: startDate.add((daysBetweenClaims), 'days').toDate(),

--- a/test/unit/services/auto-approval/checks/test-has-claimed-less-than-max-times-this-year.js
+++ b/test/unit/services/auto-approval/checks/test-has-claimed-less-than-max-times-this-year.js
@@ -8,11 +8,11 @@ var initialClaimId = 800000000
 const now = dateFormatter.now()
 
 describe('services/auto-approval/checks/has-claimed-less-than-max-times-this-year', function () {
-  it('should return false if the number of claims made for the current year is equal to 26', function () {
+  it('should return true if the number of claims made for the current year is equal to 26', function () {
     var autoApprovalData = generateAutoApprovalDataWithPreviousClaims(26, now.clone().subtract(1, 'years'))
 
     var checkResult = hasClaimedLessThanMaxTimesThisYear(autoApprovalData)
-    expect(checkResult.result).to.equal(false)
+    expect(checkResult.result).to.equal(true)
   })
 
   it('should return false if the number of claims made for the current year is greater than 26', function () {


### PR DESCRIPTION
- Fixed issue where claim being processed wasn't being counted when checking max claims per month
- Added check to exclude claims that fall outside of the current month
- Fixed issue in has-claimed-less-than-max-times-this-year - should correctly pass check if count is equal to max

See #137 