### PR TITLE
Chore/clean up files

### DIFF
--- a/app/services/cleanup-old-data/delete-old-files.js
+++ b/app/services/cleanup-old-data/delete-old-files.js
@@ -1,0 +1,15 @@
+const Promise = require('bluebird')
+const fs = require('fs')
+const getClaimDocuments = require('../data/get-claim-documents')
+
+module.exports = function (eligibilityId, claimId, reference) {
+  return getClaimDocuments('ExtSchema', reference, eligibilityId, claimId)
+    .then(function (claimDocuments) {
+      claimDocuments.forEach(function (document) {
+        if (document.FilePath) {
+          fs.unlinkSync(document.FilePath)
+        }
+      })
+      return Promise.resolve()
+    })
+}

--- a/app/services/cleanup-old-data/delete-old-files.js
+++ b/app/services/cleanup-old-data/delete-old-files.js
@@ -5,7 +5,6 @@ const getClaimDocuments = require('../data/get-claim-documents')
 module.exports = function (eligibilityId, claimId, reference) {
   return getClaimDocuments('ExtSchema', reference, eligibilityId, claimId)
     .then(function (claimDocuments) {
-      console.log(claimDocuments)
       claimDocuments.forEach(function (document) {
         if (document.Filepath) {
           fs.unlinkSync(document.Filepath)

--- a/app/services/cleanup-old-data/delete-old-files.js
+++ b/app/services/cleanup-old-data/delete-old-files.js
@@ -5,9 +5,10 @@ const getClaimDocuments = require('../data/get-claim-documents')
 module.exports = function (eligibilityId, claimId, reference) {
   return getClaimDocuments('ExtSchema', reference, eligibilityId, claimId)
     .then(function (claimDocuments) {
+      console.log(claimDocuments)
       claimDocuments.forEach(function (document) {
-        if (document.FilePath) {
-          fs.unlinkSync(document.FilePath)
+        if (document.Filepath) {
+          fs.unlinkSync(document.Filepath)
         }
       })
       return Promise.resolve()

--- a/app/services/data/get-old-claim-data.js
+++ b/app/services/data/get-old-claim-data.js
@@ -3,6 +3,6 @@ const knex = require('knex')(config)
 
 module.exports = function (dateThreshold) {
   return knex('ExtSchema.Claim')
-    .select('Claim.EligibilityId', 'Claim.ClaimId')
+    .select('Claim.EligibilityId', 'Claim.ClaimId', 'Claim.Reference')
     .where('Claim.DateCreated', '<', dateThreshold)
 }

--- a/app/services/data/get-old-claim-document-data.js
+++ b/app/services/data/get-old-claim-document-data.js
@@ -1,0 +1,8 @@
+const config = require('../../../knexfile').asyncworker
+const knex = require('knex')(config)
+
+module.exports = function (dateThreshold) {
+  return knex('ExtSchema.ClaimDocument')
+    .select('ClaimDocument.EligibilityId', 'ClaimDocument.ClaimId', 'ClaimDocument.Reference')
+    .where('ClaimDocument.DateSubmitted', '<', dateThreshold)
+}

--- a/app/services/data/get-old-eligibility-data.js
+++ b/app/services/data/get-old-eligibility-data.js
@@ -4,6 +4,6 @@ const knex = require('knex')(config)
 module.exports = function (dateThreshold) {
   return knex('ExtSchema.Eligibility')
     .leftJoin('ExtSchema.Claim', 'Eligibility.EligibilityId', 'Claim.EligibilityId')
-    .select('Eligibility.EligibilityId', 'Claim.ClaimId')
+    .select('Eligibility.EligibilityId', 'Claim.ClaimId', 'Claim.Reference')
     .where('Eligibility.DateCreated', '<', dateThreshold)
 }

--- a/app/services/workers/cleanup-old-data.js
+++ b/app/services/workers/cleanup-old-data.js
@@ -4,6 +4,7 @@ const config = require('../../../config')
 const getOldEligibilityData = require('../data/get-old-eligibility-data')
 const getOldClaimData = require('../data/get-old-claim-data')
 const deleteClaimFromExternal = require('../data/delete-claim-from-external')
+const deleteOldFiles = require('../cleanup-old-data/delete-old-files')
 
 module.exports.execute = function (task) {
   var maxDaysBeforeDeleteData = parseInt(config.EXTERNAL_MAX_DAYS_BEFORE_DELETE_OLD_DATA)
@@ -19,7 +20,10 @@ function cleanEligibilityData (dateThreshold) {
   return getOldEligibilityData(dateThreshold)
     .then(function (oldEligibilityData) {
       oldEligibilityData.forEach(function (eligibilityData) {
-        return deleteClaimFromExternal(eligibilityData.EligibilityId, eligibilityData.ClaimId)
+        return deleteOldFiles(eligibilityData.EligibilityId, eligibilityData.ClaimId, eligibilityData.Reference)
+          .then(function () {
+            return deleteClaimFromExternal(eligibilityData.EligibilityId, eligibilityData.ClaimId)
+          })
       })
     })
 }
@@ -28,7 +32,10 @@ function cleanClaimData (dateThreshold) {
   return getOldClaimData(dateThreshold)
     .then(function (oldClaimData) {
       oldClaimData.forEach(function (claimData) {
-        return deleteClaimFromExternal(claimData.EligibilityId, claimData.ClaimId)
+        return deleteOldFiles(claimData.EligibilityId, claimData.ClaimId, claimData.Reference)
+          .then(function () {
+            return deleteClaimFromExternal(claimData.EligibilityId, claimData.ClaimId)
+          })
       })
     })
 }

--- a/app/services/workers/cleanup-old-data.js
+++ b/app/services/workers/cleanup-old-data.js
@@ -3,6 +3,7 @@ const config = require('../../../config')
 
 const getOldEligibilityData = require('../data/get-old-eligibility-data')
 const getOldClaimData = require('../data/get-old-claim-data')
+const getOldClaimDocumentData = require('../data/get-old-claim-document-data')
 const deleteClaimFromExternal = require('../data/delete-claim-from-external')
 const deleteOldFiles = require('../cleanup-old-data/delete-old-files')
 
@@ -13,6 +14,9 @@ module.exports.execute = function (task) {
   return cleanEligibilityData(dateThreshold)
     .then(function () {
       return cleanClaimData(dateThreshold)
+        .then(function () {
+          return cleanClaimDocumentData(dateThreshold)
+        })
     })
 }
 
@@ -35,6 +39,18 @@ function cleanClaimData (dateThreshold) {
         return deleteOldFiles(claimData.EligibilityId, claimData.ClaimId, claimData.Reference)
           .then(function () {
             return deleteClaimFromExternal(claimData.EligibilityId, claimData.ClaimId)
+          })
+      })
+    })
+}
+
+function cleanClaimDocumentData (dateThreshold) {
+  return getOldClaimDocumentData(dateThreshold)
+    .then(function (oldClaimDocumentData) {
+      oldClaimDocumentData.forEach(function (documentData) {
+        return deleteOldFiles(documentData.EligibilityId, documentData.ClaimId, documentData.Reference)
+          .then(function () {
+            return deleteClaimFromExternal(documentData.EligibilityId, documentData.ClaimId)
           })
       })
     })

--- a/config.js
+++ b/config.js
@@ -19,7 +19,7 @@ module.exports = {
   // Worker
   ASYNC_WORKER_CRON: process.env.APVS_ASYNC_WORKER_CRON || '*/2 * * * * *',
   ASYNC_WORKER_BATCH_SIZE: process.env.APVS_ASYNC_WORKER_BATCH_SIZE || '5',
-  DAILY_TASKS_CRON: process.env.APVS_DAILY_TASKS_CRON || '* * * * * *', // default every day at 0430
+  DAILY_TASKS_CRON: process.env.APVS_DAILY_TASKS_CRON || '30 04 * * * *', // default every day at 0430
   NUMBER_OF_DAYS_AFTER_DATE_OF_JOURNEY_FOR_ADVANCE_REMINDER: process.env.APVS_NUMBER_OF_DAYS_AFTER_DATE_OF_JOURNEY_FOR_ADVANCE_REMINDER || '1',
   ARCHIVE_CLAIMS_AFTER_DAYS: process.env.APVS_ARCHIVE_CLAIMS_AFTER_DAYS || '365',
 

--- a/config.js
+++ b/config.js
@@ -19,7 +19,7 @@ module.exports = {
   // Worker
   ASYNC_WORKER_CRON: process.env.APVS_ASYNC_WORKER_CRON || '*/2 * * * * *',
   ASYNC_WORKER_BATCH_SIZE: process.env.APVS_ASYNC_WORKER_BATCH_SIZE || '5',
-  DAILY_TASKS_CRON: process.env.APVS_DAILY_TASKS_CRON || '30 04 * * * *', // default every day at 0430
+  DAILY_TASKS_CRON: process.env.APVS_DAILY_TASKS_CRON || '* * * * * *', // default every day at 0430
   NUMBER_OF_DAYS_AFTER_DATE_OF_JOURNEY_FOR_ADVANCE_REMINDER: process.env.APVS_NUMBER_OF_DAYS_AFTER_DATE_OF_JOURNEY_FOR_ADVANCE_REMINDER || '1',
   ARCHIVE_CLAIMS_AFTER_DAYS: process.env.APVS_ARCHIVE_CLAIMS_AFTER_DAYS || '365',
 

--- a/test/integration/services/data/test-get-old-claim-document-data.js
+++ b/test/integration/services/data/test-get-old-claim-document-data.js
@@ -1,0 +1,124 @@
+const expect = require('chai').expect
+const knexfile = require('../../../../knexfile').asyncworker
+const knex = require('knex')(knexfile)
+const config = require('../../../../config')
+const moment = require('moment')
+const testHelper = require('../../../test-helper')
+
+const getOldClaimDocumentData = require('../../../../app/services/data/get-old-claim-document-data')
+
+describe('services/data/get-old-claim-document-data', function () {
+  var maxAgeInDays = parseInt(config.EXTERNAL_MAX_DAYS_BEFORE_DELETE_OLD_DATA)
+  var reference1 = 'GETDOC1'
+  var reference2 = 'GETDOC2'
+  var reference3 = 'GETDOC3'
+  var reference4 = 'GETDOC4'
+  var claimId1
+  var claimId2
+  var claimId3
+  var claimId4
+
+  var dateThreshold = moment().subtract(maxAgeInDays, 'days').toDate()
+  var olderThanMaxAge = moment().subtract(maxAgeInDays + 1, 'days').toDate()
+  var lessThanMaxAge = moment().subtract(maxAgeInDays - 1, 'days').toDate()
+
+  before(function () {
+    return Promise.all([
+      // Old claim with eligibility
+      createTestData(reference1, olderThanMaxAge, false)
+        .then(function (ids) {
+          claimId1 = ids.claimId
+        }),
+      // Old claim without eligibility
+      createTestData(reference2, olderThanMaxAge, true)
+        .then(function (ids) {
+          claimId2 = ids.claimId
+        }),
+      // Newer claim with eligibility
+      createTestData(reference3, lessThanMaxAge, false)
+        .then(function (ids) {
+          claimId3 = ids.claimId
+        }),
+      // Newer claim without eligibility
+      createTestData(reference4, lessThanMaxAge, true)
+        .then(function (ids) {
+          claimId4 = ids.claimId
+        })
+    ])
+  })
+
+  it('should retrieve claim document records past the date threshold', function () {
+    return getOldClaimDocumentData(dateThreshold)
+      .then(function (results) {
+        var claimDocument1Found = claimDocumentsExist(claimId1, results)
+        var claimDocument2Found = claimDocumentsExist(claimId2, results)
+
+        expect(claimDocument1Found).to.be.true
+        expect(claimDocument2Found).to.be.true
+      })
+  })
+
+  it('should not retrieve claim records within the date threshold', function () {
+    return getOldClaimDocumentData(dateThreshold)
+      .then(function (results) {
+        var claimDocument3Found = claimDocumentsExist(claimId3, results)
+        var claimDocument4Found = claimDocumentsExist(claimId4, results)
+
+        expect(claimDocument3Found).to.be.false
+        expect(claimDocument4Found).to.be.false
+      })
+  })
+
+  after(function () {
+    return Promise.all([
+      testHelper.deleteAll(reference1, 'ExtSchema'),
+      testHelper.deleteAll(reference2, 'ExtSchema'),
+      testHelper.deleteAll(reference3, 'ExtSchema'),
+      testHelper.deleteAll(reference4, 'ExtSchema')
+    ])
+  })
+})
+
+function createTestData (ref, dateSubmitted, deleteEligibility) {
+  var returnObject = {}
+
+  return testHelper.insertClaimEligibilityData('ExtSchema', ref)
+    .then(function (ids) {
+      returnObject.eligibilityId = ids.eligibilityId
+      returnObject.claimId = ids.claimId
+
+      return knex('ExtSchema.ClaimDocument')
+        .where('ClaimId', returnObject.claimId)
+        .update({
+          'DateSubmitted': dateSubmitted
+        })
+        .then(function () {
+          if (deleteEligibility) {
+            return Promise.all([
+              deleteFromTable(returnObject.eligibilityId, 'Prisoner'),
+              deleteFromTable(returnObject.eligibilityId, 'Visitor')
+            ])
+            .then(function () {
+              return deleteFromTable(returnObject.eligibilityId, 'Eligibility')
+            })
+          }
+        })
+    })
+    .then(function () {
+      return returnObject
+    })
+}
+
+function deleteFromTable (eligibilityId, tableName) {
+  return knex(`ExtSchema.${tableName}`)
+    .where('EligibilityId', eligibilityId)
+    .del()
+}
+
+function claimDocumentsExist (value, collection) {
+  var result = collection.filter(function (item) {
+    return item.ClaimId === value
+  })
+
+  return result.length > 0
+}

--- a/test/unit/services/cleanup-old-data/test-delete-old-files.js
+++ b/test/unit/services/cleanup-old-data/test-delete-old-files.js
@@ -1,0 +1,60 @@
+const expect = require('chai').expect
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const CLAIM_ID = 1234
+const ELIGIBILITY_ID = 4321
+const REFERENCE = 'DELFILE'
+const CLAIM_DOCUMENT_FILEPATH = [{FilePath: '1'}]
+const CLAIM_DOCUMENT_NO_FILEPATH = [{}]
+const CLAIM_DOCUMENT_NO_DATA = []
+
+var fs
+var getClaimDocuments
+var calledFsUnlinkSync = false
+
+var deleteOldFiles
+
+describe('services/cleanup-old-data/delete-old-files', function () {
+  beforeEach(function () {
+    getClaimDocuments = sinon.stub()
+    calledFsUnlinkSync = false
+
+    fs = {
+      unlinkSync: function () {
+        calledFsUnlinkSync = true
+      }
+    }
+
+    deleteOldFiles = proxyquire('../../../../app/services/cleanup-old-data/delete-old-files', {
+      'fs': fs,
+      '../data/get-claim-documents': getClaimDocuments
+    })
+  })
+
+  it('should call to delete a file based on filepath', function () {
+    getClaimDocuments.resolves(CLAIM_DOCUMENT_FILEPATH)
+    return deleteOldFiles(ELIGIBILITY_ID, CLAIM_ID, REFERENCE)
+      .then(function () {
+        expect(getClaimDocuments.calledWith('ExtSchema', REFERENCE, ELIGIBILITY_ID, CLAIM_ID)).to.be.true
+        expect(calledFsUnlinkSync).to.be.true
+      })
+  })
+
+  it('should copy eligibility directory to archive when archiving eligibility', function () {
+    getClaimDocuments.resolves(CLAIM_DOCUMENT_NO_FILEPATH)
+    return deleteOldFiles(ELIGIBILITY_ID, CLAIM_ID, REFERENCE)
+      .then(function () {
+        expect(calledFsUnlinkSync).to.be.false
+      })
+  })
+
+  it('should not call to delete a file for no claim data', function () {
+    getClaimDocuments.resolves(CLAIM_DOCUMENT_NO_DATA)
+    return deleteOldFiles(ELIGIBILITY_ID, CLAIM_ID, REFERENCE)
+      .then(function () {
+        expect(calledFsUnlinkSync).to.be.false
+      })
+  })
+})

--- a/test/unit/services/cleanup-old-data/test-delete-old-files.js
+++ b/test/unit/services/cleanup-old-data/test-delete-old-files.js
@@ -6,7 +6,7 @@ require('sinon-bluebird')
 const CLAIM_ID = 1234
 const ELIGIBILITY_ID = 4321
 const REFERENCE = 'DELFILE'
-const CLAIM_DOCUMENT_FILEPATH = [{FilePath: '1'}]
+const CLAIM_DOCUMENT_FILEPATH = [{Filepath: '1'}]
 const CLAIM_DOCUMENT_NO_FILEPATH = [{}]
 const CLAIM_DOCUMENT_NO_DATA = []
 

--- a/test/unit/services/workers/test-cleanup-old-data.js
+++ b/test/unit/services/workers/test-cleanup-old-data.js
@@ -23,26 +23,25 @@ const OLD_CLAIM_DATA = [
   }
 ]
 
-var getOldEligibilityDataStub = sinon.stub()
-var getOldClaimDataStub = sinon.stub()
-var deleteClaimFromExternalStub = sinon.stub().resolves()
+var getOldEligibilityDataStub
+var getOldClaimDataStub
+var deleteClaimFromExternalStub
+var deleteOldFilesStub
 
-var cleanupOldData = proxyquire('../../../../app/services/workers/cleanup-old-data', {
-  '../data/get-old-eligibility-data': getOldEligibilityDataStub,
-  '../data/get-old-claim-data': getOldClaimDataStub,
-  '../data/delete-claim-from-external': deleteClaimFromExternalStub
-})
+var cleanupOldData
 
 describe('services/workers/cleanup-old-data', function () {
   beforeEach(function () {
     getOldEligibilityDataStub = sinon.stub()
     getOldClaimDataStub = sinon.stub()
     deleteClaimFromExternalStub = sinon.stub().resolves()
+    deleteOldFilesStub = sinon.stub().resolves()
 
     cleanupOldData = proxyquire('../../../../app/services/workers/cleanup-old-data', {
       '../data/get-old-eligibility-data': getOldEligibilityDataStub,
       '../data/get-old-claim-data': getOldClaimDataStub,
-      '../data/delete-claim-from-external': deleteClaimFromExternalStub
+      '../data/delete-claim-from-external': deleteClaimFromExternalStub,
+      '../cleanup-old-data/delete-old-files': deleteOldFilesStub
     })
   })
 
@@ -53,6 +52,7 @@ describe('services/workers/cleanup-old-data', function () {
     return cleanupOldData.execute({}).then(function () {
       expect(getOldEligibilityDataStub.calledOnce).to.be.true
       expect(getOldClaimDataStub.calledOnce).to.be.true
+      expect(deleteOldFilesStub.calledTwice).to.be.true
       expect(deleteClaimFromExternalStub.calledWith(OLD_ELIGIBILITY_DATA[0].EligibilityId, OLD_ELIGIBILITY_DATA[0].ClaimId)).to.be.true
       expect(deleteClaimFromExternalStub.calledWith(OLD_ELIGIBILITY_DATA[1].EligibilityId, OLD_ELIGIBILITY_DATA[1].ClaimId)).to.be.true
     })
@@ -65,6 +65,7 @@ describe('services/workers/cleanup-old-data', function () {
     return cleanupOldData.execute({}).then(function () {
       expect(getOldEligibilityDataStub.calledOnce).to.be.true
       expect(getOldClaimDataStub.calledOnce).to.be.true
+      expect(deleteOldFilesStub.calledTwice).to.be.true
       expect(deleteClaimFromExternalStub.calledWith(OLD_CLAIM_DATA[0].EligibilityId, OLD_CLAIM_DATA[0].ClaimId)).to.be.true
       expect(deleteClaimFromExternalStub.calledWith(OLD_CLAIM_DATA[1].EligibilityId, OLD_CLAIM_DATA[1].ClaimId)).to.be.true
     })

--- a/test/unit/services/workers/test-cleanup-old-data.js
+++ b/test/unit/services/workers/test-cleanup-old-data.js
@@ -23,8 +23,18 @@ const OLD_CLAIM_DATA = [
   }
 ]
 
+const OLD_CLAIM_DOCUMENT_DATA = [
+  {
+    ClaimId: 5
+  },
+  {
+    ClaimId: 6
+  }
+]
+
 var getOldEligibilityDataStub
 var getOldClaimDataStub
+var getOldClaimDocumentDataStub
 var deleteClaimFromExternalStub
 var deleteOldFilesStub
 
@@ -34,12 +44,14 @@ describe('services/workers/cleanup-old-data', function () {
   beforeEach(function () {
     getOldEligibilityDataStub = sinon.stub()
     getOldClaimDataStub = sinon.stub()
+    getOldClaimDocumentDataStub = sinon.stub()
     deleteClaimFromExternalStub = sinon.stub().resolves()
     deleteOldFilesStub = sinon.stub().resolves()
 
     cleanupOldData = proxyquire('../../../../app/services/workers/cleanup-old-data', {
       '../data/get-old-eligibility-data': getOldEligibilityDataStub,
       '../data/get-old-claim-data': getOldClaimDataStub,
+      '../data/get-old-claim-document-data': getOldClaimDocumentDataStub,
       '../data/delete-claim-from-external': deleteClaimFromExternalStub,
       '../cleanup-old-data/delete-old-files': deleteOldFilesStub
     })
@@ -48,6 +60,7 @@ describe('services/workers/cleanup-old-data', function () {
   it('should retrieve any old eligibility records and delete them from the external database', function () {
     getOldEligibilityDataStub.resolves(OLD_ELIGIBILITY_DATA)
     getOldClaimDataStub.resolves([])
+    getOldClaimDocumentDataStub.resolves([])
 
     return cleanupOldData.execute({}).then(function () {
       expect(getOldEligibilityDataStub.calledOnce).to.be.true
@@ -61,6 +74,7 @@ describe('services/workers/cleanup-old-data', function () {
   it('should retrieve any old claim records and delete them from the external database', function () {
     getOldEligibilityDataStub.resolves([])
     getOldClaimDataStub.resolves(OLD_CLAIM_DATA)
+    getOldClaimDocumentDataStub.resolves([])
 
     return cleanupOldData.execute({}).then(function () {
       expect(getOldEligibilityDataStub.calledOnce).to.be.true
@@ -68,6 +82,20 @@ describe('services/workers/cleanup-old-data', function () {
       expect(deleteOldFilesStub.calledTwice).to.be.true
       expect(deleteClaimFromExternalStub.calledWith(OLD_CLAIM_DATA[0].EligibilityId, OLD_CLAIM_DATA[0].ClaimId)).to.be.true
       expect(deleteClaimFromExternalStub.calledWith(OLD_CLAIM_DATA[1].EligibilityId, OLD_CLAIM_DATA[1].ClaimId)).to.be.true
+    })
+  })
+
+  it('should retrieve any old claim document records and delete them from the external database', function () {
+    getOldEligibilityDataStub.resolves([])
+    getOldClaimDataStub.resolves([])
+    getOldClaimDocumentDataStub.resolves(OLD_CLAIM_DOCUMENT_DATA)
+
+    return cleanupOldData.execute({}).then(function () {
+      expect(getOldEligibilityDataStub.calledOnce).to.be.true
+      expect(getOldClaimDataStub.calledOnce).to.be.true
+      expect(deleteOldFilesStub.calledTwice).to.be.true
+      expect(deleteClaimFromExternalStub.calledWith(OLD_CLAIM_DOCUMENT_DATA[0].EligibilityId, OLD_CLAIM_DOCUMENT_DATA[0].ClaimId)).to.be.true
+      expect(deleteClaimFromExternalStub.calledWith(OLD_CLAIM_DOCUMENT_DATA[1].EligibilityId, OLD_CLAIM_DOCUMENT_DATA[1].ClaimId)).to.be.true
     })
   })
 })


### PR DESCRIPTION
Added method to delete old files not submitted and to clean up old claim document records. Related to issue #140 
 
* Added delete old files
* Added clean up old claim documents function

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards