### PR TITLE
Feature/apvs 0038/postoffice postcode format

### DIFF
--- a/app/services/workers/generate-payout-payments.js
+++ b/app/services/workers/generate-payout-payments.js
@@ -45,10 +45,9 @@ function getClaimIdsFromPaymentData (paymentData, claimIdIndex) {
 // POI code, blank, blank, Reference, blank, blank, blank, blank, blank, template code
 function formatCSVData (paymentData, claimIdIndex) {
   paymentData.forEach(function (data) {
-
     // Ensures there is a space in the postcode
     var postCodeIndex = 8
-    if(data[postCodeIndex].indexOf(' ') < 0) {
+    if (data[postCodeIndex].indexOf(' ') < 0) {
       data[postCodeIndex] = data[postCodeIndex].replace(/^(.*)(.{3})$/, '$1 $2')
     }
 

--- a/app/services/workers/generate-payout-payments.js
+++ b/app/services/workers/generate-payout-payments.js
@@ -45,6 +45,13 @@ function getClaimIdsFromPaymentData (paymentData, claimIdIndex) {
 // POI code, blank, blank, Reference, blank, blank, blank, blank, blank, template code
 function formatCSVData (paymentData, claimIdIndex) {
   paymentData.forEach(function (data) {
+
+    // Ensures there is a space in the postcode
+    var postCodeIndex = 8
+    if(data[postCodeIndex].indexOf(' ') < 0) {
+      data[postCodeIndex] = data[postCodeIndex].replace(/^(.*)(.{3})$/, '$1 $2')
+    }
+
     data.splice(claimIdIndex, 1)
     data.splice(1, 0, '')
     data.splice(9, 0, '3', '', '') // 3 is the code for checking ID in POI

--- a/app/services/workers/generate-payout-payments.js
+++ b/app/services/workers/generate-payout-payments.js
@@ -9,6 +9,8 @@ const config = require('../../../config')
 const _ = require('lodash')
 const path = require('path')
 
+module.exports._test_formatCSVData = formatCSVData
+
 module.exports.execute = function (task) {
   var claimIds
   var paymentCsvFilePath
@@ -45,16 +47,16 @@ function getClaimIdsFromPaymentData (paymentData, claimIdIndex) {
 // POI code, blank, blank, Reference, blank, blank, blank, blank, blank, template code
 function formatCSVData (paymentData, claimIdIndex) {
   paymentData.forEach(function (data) {
+    data.splice(claimIdIndex, 1)
+    data.splice(1, 0, '')
+    data.splice(9, 0, '3', '', '') // 3 is the code for checking ID in POI
+    data.splice(13, 0, '', '', '', '', '', config.PAYOUT_TEMPLATE_CODE)
+
     // Ensures there is a space in the postcode
     var postCodeIndex = 8
     if (data[postCodeIndex].indexOf(' ') < 0) {
       data[postCodeIndex] = data[postCodeIndex].replace(/^(.*)(.{3})$/, '$1 $2')
     }
-
-    data.splice(claimIdIndex, 1)
-    data.splice(1, 0, '')
-    data.splice(9, 0, '3', '', '') // 3 is the code for checking ID in POI
-    data.splice(13, 0, '', '', '', '', '', config.PAYOUT_TEMPLATE_CODE)
   })
 
   return paymentData

--- a/test/integration/services/payout-payments/test-create-payout-file.js
+++ b/test/integration/services/payout-payments/test-create-payout-file.js
@@ -5,16 +5,22 @@ const readFile = Promise.promisify(require('fs').readFile)
 const unlink = Promise.promisify(require('fs').unlink)
 
 const createPaymentFile = require('../../../../app/services/payout-payments/create-payout-file')
+const generatePayoutPayments = require('../../../../app/services/workers/generate-payout-payments')
 var testFilePath
 
-const data = [
-  ['34.22', '', 'Joe', 'Bloggs$$', '123 Test Street$$', 'Test Town&&', 'Test County||', 'Test>><< Country', 'BT123BT', '3', '', '', 'V123456', '', '', '', '', '', 'TEST089-LET-001'],
-  ['12.22', '', 'Frank', 'Bloggs', '456 Test Street', 'Test Town', 'Test County', 'Test Country', 'BT126BT', '3', '', '', 'V123457', '', '', '', '', '', 'TEST089-LET-001']
+var data = [
+  ['34.22', 'Joe', 'Bloggs$$', '123 Test Street$$', 'Test Town&&', 'Test County||', 'Test>><< Country', 'BT123BT', 'V123456', 'TEST089-LET-001'],
+  ['12.22', 'Frank', 'Bloggs', '456 Test Street', 'Test Town', 'Test County', 'Test Country', 'BT12 6BT', 'V123457', 'TEST089-LET-001']
 ]
 
 describe('services/payout-payments/create-payout-file', function () {
   it('should generate valid file', function () {
-    return createPaymentFile(data)
+    var formattedData = generatePayoutPayments._test_formatCSVData(data, 9)
+    formattedData.forEach(function (row) {
+      row[row.length - 1] = 'TEST089-LET-001'
+    })
+
+    return createPaymentFile(formattedData)
       .then(function (filePath) {
         expect(filePath).to.be.not.null
         expect(filePath).to.contain(config.PAYOUT_FILENAME_PREFIX)
@@ -24,8 +30,8 @@ describe('services/payout-payments/create-payout-file', function () {
         return readFile(filePath).then(function (content) {
           var lines = content.toString().split('\n')
           expect(lines.length).to.be.equal(3)
-          expect(lines[0]).to.be.equal('34.22,,Joe,Bloggs,123 Test Street,Test Town,Test County,Test Country,BT123BT,3,,,V123456,,,,,,TEST089-LET-001')
-          expect(lines[1]).to.be.equal('12.22,,Frank,Bloggs,456 Test Street,Test Town,Test County,Test Country,BT126BT,3,,,V123457,,,,,,TEST089-LET-001')
+          expect(lines[0]).to.be.equal('34.22,,Joe,Bloggs,123 Test Street,Test Town,Test County,Test Country,BT12 3BT,3,,,V123456,,,,,,TEST089-LET-001')
+          expect(lines[1]).to.be.equal('12.22,,Frank,Bloggs,456 Test Street,Test Town,Test County,Test Country,BT12 6BT,3,,,V123457,,,,,,TEST089-LET-001')
         })
       })
   })

--- a/test/unit/services/archiving/test-move-claim-files-to-archive-file-store.js
+++ b/test/unit/services/archiving/test-move-claim-files-to-archive-file-store.js
@@ -59,8 +59,8 @@ describe('services/archiving/move-claim-files-to-archive-file-store', function (
   it('should copy claim directory to archive when not archiving eligibility', function () {
     return moveClaimFilesToArchiveFileStore(CLAIM_DATA).then(function () {
       expect(calledMove).to.be.true
-      expect(sourceDirectory).to.be.equal(path.normalize(`${UPLOAD_LOCATION}/${REFERENCE}-${ELIGIBILITY_ID}/${CLAIM_ID}`))
-      expect(targetDirectory).to.be.equal(path.normalize(`${ARCHIVE_LOCATION}/${REFERENCE}-${ELIGIBILITY_ID}/${CLAIM_ID}`))
+      expect(sourceDirectory).to.be.equal(`${UPLOAD_LOCATION}/${REFERENCE}-${ELIGIBILITY_ID}/${CLAIM_ID}`)
+      expect(targetDirectory).to.be.equal(`${ARCHIVE_LOCATION}/${REFERENCE}-${ELIGIBILITY_ID}/${CLAIM_ID}`)
     })
   })
 

--- a/test/unit/services/archiving/test-move-claim-files-to-archive-file-store.js
+++ b/test/unit/services/archiving/test-move-claim-files-to-archive-file-store.js
@@ -1,5 +1,6 @@
 const expect = require('chai').expect
 const proxyquire = require('proxyquire')
+const path = require('path')
 
 const CLAIM_ID = 1234
 const ELIGIBILITY_ID = 4321
@@ -58,8 +59,8 @@ describe('services/archiving/move-claim-files-to-archive-file-store', function (
   it('should copy claim directory to archive when not archiving eligibility', function () {
     return moveClaimFilesToArchiveFileStore(CLAIM_DATA).then(function () {
       expect(calledMove).to.be.true
-      expect(sourceDirectory).to.be.equal(`${UPLOAD_LOCATION}/${REFERENCE}-${ELIGIBILITY_ID}/${CLAIM_ID}`)
-      expect(targetDirectory).to.be.equal(`${ARCHIVE_LOCATION}/${REFERENCE}-${ELIGIBILITY_ID}/${CLAIM_ID}`)
+      expect(sourceDirectory).to.be.equal(path.normalize(`${UPLOAD_LOCATION}/${REFERENCE}-${ELIGIBILITY_ID}/${CLAIM_ID}`))
+      expect(targetDirectory).to.be.equal(path.normalize(`${ARCHIVE_LOCATION}/${REFERENCE}-${ELIGIBILITY_ID}/${CLAIM_ID}`))
     })
   })
 
@@ -67,8 +68,8 @@ describe('services/archiving/move-claim-files-to-archive-file-store', function (
     return moveClaimFilesToArchiveFileStore(CLAIM_DATA_DELETE_ELIGIBILTIY).then(function () {
       expect(calledFsReaddirSync).to.be.true
       expect(calledFsRmdirSync).to.be.true
-      expect(sourceDirectory).to.be.equal(`${UPLOAD_LOCATION}/${REFERENCE}-${ELIGIBILITY_ID}/${ELIGIBILITY_DIR}`)
-      expect(targetDirectory).to.be.equal(`${ARCHIVE_LOCATION}/${REFERENCE}-${ELIGIBILITY_ID}/${ELIGIBILITY_DIR}`)
+      expect(sourceDirectory).to.be.equal(path.normalize(`${UPLOAD_LOCATION}/${REFERENCE}-${ELIGIBILITY_ID}/${ELIGIBILITY_DIR}`))
+      expect(targetDirectory).to.be.equal(path.normalize(`${ARCHIVE_LOCATION}/${REFERENCE}-${ELIGIBILITY_ID}/${ELIGIBILITY_DIR}`))
     })
   })
 


### PR DESCRIPTION
apvs-38 - Updating postcode format in post office CSV

Updating the format of the CSV file to always include a space in the post code. Tests updated to reflect this, and the formatCSVData function in generate-payout-payments has been exported to allow it to be tested. Test file paths normalised so they work on Windows as well.
